### PR TITLE
[Fix] #27 - API 변경사항 반영 및 UI 수정

### DIFF
--- a/Terbuck/Core/CoreAppleLogin/Sources/AppleLoginService.swift
+++ b/Terbuck/Core/CoreAppleLogin/Sources/AppleLoginService.swift
@@ -36,7 +36,11 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
             return
         }
         
-        let userName = credential.fullName?.givenName ?? "Unknown"
+        let fullName = credential.fullName
+        let givenName = fullName?.givenName ?? ""
+        let familyName = fullName?.familyName ?? ""
+        let userName = "\(familyName)\(givenName)"
+        
         let authCode = String(data: credential.authorizationCode ?? Data(), encoding: .utf8) ?? ""
         
         print("애플로그인 결과 반환",authCode, userName)

--- a/Terbuck/Core/CoreNetwork/Sources/Auth/DTO/Request/AppleLoginRequestDTO.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/Auth/DTO/Request/AppleLoginRequestDTO.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public struct AppleLoginRequestDTO: Encodable {
     let code: String
-    let name: String?
+    let name: String
     
-    public init(code: String, name: String?) {
+    public init(code: String, name: String) {
         self.code = code
         self.name = name
     }

--- a/Terbuck/Core/CoreNetwork/Sources/Base/APIClient.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/Base/APIClient.swift
@@ -92,7 +92,24 @@ private extension APIClient {
             }
         }
         
-        print("🚀 URL: \(String(describing: urlRequest.url))")
+        print("🚀 URL: \(urlRequest.url?.absoluteString ?? "nil")")
+        print("🚀 Method: \(urlRequest.httpMethod ?? "nil")")
+        
+        print("🚀 Headers:")
+        if let headers = urlRequest.allHTTPHeaderFields {
+            for (key, value) in headers {
+                print("    \(key): \(value)")
+            }
+        } else {
+            print("    (no headers)")
+        }
+        
+        if let httpBody = urlRequest.httpBody,
+           let bodyString = String(data: httpBody, encoding: .utf8) {
+            print("🚀 Body:\n\(bodyString)")
+        } else {
+            print("🚀 Body: (no body)")
+        }
         
         return urlRequest
     }
@@ -154,6 +171,17 @@ private extension APIClient {
         
         print("🚀 StatusCode: \(String(describing: httpResponse.statusCode))")
         
+        // 204 No Content 대응
+        if httpResponse.statusCode == 204 {
+            if T.self == EmptyResponseDTO.self, let emptyResult = EmptyResponseDTO() as? T {
+                print("📦 EmptyResponseDTO 반환")
+                return emptyResult
+            } else {
+                throw NetworkError.noData
+            }
+        }
+        
+        // 정상적으로 body 가 있어야 하는 경우
         guard let data = data else {
             throw NetworkError.noData
         }

--- a/Terbuck/Core/CoreNetwork/Sources/Member/DTO/Response/SearchStudentInfoResponseDTO.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/Member/DTO/Response/SearchStudentInfoResponseDTO.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 public struct SearchStudentInfoResponseDTO: Decodable {
-    public let studentNumber: String
     public let name: String
-    public let imageURL: String
+    public let university: String
+    public let isRegistered: Bool
+    public let studentNumber: String?
+    public let imageURL: String?
 }

--- a/Terbuck/Core/CoreNetwork/Sources/Member/MemberAPIEndpoint.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/Member/MemberAPIEndpoint.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public enum MemberAPIEndpoint {
     case postSignin(SigninRequestDTO)
+    case deleteMemeber
     case patchUniversity(ChangeUniversityRequestDTO)
     case getStudentId
     case putRegisterStudentId(RegisterStudentIDRequestDTO)
@@ -24,6 +25,8 @@ extension MemberAPIEndpoint: EndpointProtocol {
         switch self {
         case .postSignin:
             return basePath.rawValue + "/signin"
+        case .deleteMemeber:
+            return basePath.rawValue
         case .patchUniversity:
             return basePath.rawValue + "/univ"
         case .getStudentId, .putRegisterStudentId, .deleteStudentId:
@@ -41,7 +44,7 @@ extension MemberAPIEndpoint: EndpointProtocol {
             return .get
         case .putRegisterStudentId:
             return .put
-        case .deleteStudentId:
+        case .deleteMemeber, .deleteStudentId:
             return .delete
         }
     }

--- a/Terbuck/Core/CoreNetwork/Sources/Store/DTO/Response/SearchStoreDetailResponseDTO.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/Store/DTO/Response/SearchStoreDetailResponseDTO.swift
@@ -14,13 +14,27 @@ public struct SearchStoreDetailResponseDTO: Decodable {
     public let address: String
     public let benefitCount: Int
     public let benefitList: [StoreBenefitData]
+    public let usagesList: [SearchDetailStoreUsagesData]
     
-    public init(name: String, shopLink: String, imageList: [String], address: String, benefitCount: Int, benefitList: [StoreBenefitData]) {
+    public init(
+        name: String,
+        shopLink: String,
+        imageList: [String],
+        address: String,
+        benefitCount: Int,
+        benefitList: [StoreBenefitData],
+        usagesList: [SearchDetailStoreUsagesData]
+    ) {
         self.name = name
         self.shopLink = shopLink
         self.imageList = imageList
         self.address = address
         self.benefitCount = benefitCount
         self.benefitList = benefitList
+        self.usagesList = usagesList
     }
+}
+
+public struct SearchDetailStoreUsagesData: Decodable {
+    public let introduction: String
 }

--- a/Terbuck/DesignSystem/Sources/Button/SocialLoginButton.swift
+++ b/Terbuck/DesignSystem/Sources/Button/SocialLoginButton.swift
@@ -71,7 +71,7 @@ private extension SocialLoginButton {
     func setupStyle(type: SocialButtonType) {
         if type.hasBorder {
             self.layer.borderColor =  DesignSystem.Color.uiColor(.terbuckBlack50).cgColor
-            self.layer.borderWidth = 0.5
+            self.layer.borderWidth = 0.7
         }
         
         self.backgroundColor = type.backgroundColor

--- a/Terbuck/DesignSystem/Sources/Components/CustomAlertViewController.swift
+++ b/Terbuck/DesignSystem/Sources/Components/CustomAlertViewController.swift
@@ -129,7 +129,7 @@ private extension CustomAlertViewController {
          }
          
          subTitleLabel.do {
-             $0.numberOfLines = 2
+             $0.numberOfLines = 0
              $0.textAlignment = .center
              
              let paragraph = NSMutableParagraphStyle()

--- a/Terbuck/DesignSystem/Sources/ToastMessage/ToastType.swift
+++ b/Terbuck/DesignSystem/Sources/ToastMessage/ToastType.swift
@@ -7,8 +7,13 @@
 
 import UIKit
 
+public enum AuthorizedType {
+    case home
+    case detailStore
+}
+
 public enum ToastType {
-    case notAuthorized
+    case notAuthorized(type: AuthorizedType)
     case noticeStudentCard
     case alarmStudentCard
     case changeUniversity
@@ -78,6 +83,12 @@ public enum ToastType {
     
     var padding: CGFloat {
         switch self {
+        case .notAuthorized(let type):
+            if type == .detailStore {
+                return 68
+            } else {
+                return 16
+            }
         case .noticeStudentCard, .alarmStudentCard, .moreBenefit:
             return 68
         default:

--- a/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
@@ -62,7 +62,6 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        UserDefaultsManager.shared.set("서울과학기술대학교", for: .university)
         setupStyle(UserDefaultsManager.shared.bool(for: .isStudentIDAuthenticated))
         setupHierarchy()
         setupLayout()
@@ -120,7 +119,7 @@ private extension HomeViewController {
                 guard let self else { return }
 
                 if authResult == false {
-                    ToastManager.shared.showToast(from: self, type: .notAuthorized) {
+                    ToastManager.shared.showToast(from: self, type: .notAuthorized(type: .home)) {
                         self.coordinator?.registerStudentID()
                     }
                 }

--- a/Terbuck/Feature/MypageFeature/Sources/Data/Entity/SearchStudentInfoEntity.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/Data/Entity/SearchStudentInfoEntity.swift
@@ -9,16 +9,20 @@ import Foundation
 import CoreNetwork
 
 public struct SearchStudentInfoEntity {
-    let studentNum: String
     let studentName: String
-    let imageUrl: String
+    let universityName: String
+    let isAuth: Bool
+    let studentNum: String?
+    let imageUrl: String?
 }
 
 extension SearchStudentInfoResponseDTO {
     func toEntity() -> SearchStudentInfoEntity {
         return SearchStudentInfoEntity(
-            studentNum: studentNumber,
             studentName: name,
+            universityName: university,
+            isAuth: isRegistered,
+            studentNum: studentNumber,
             imageUrl: imageURL
         )
     }

--- a/Terbuck/Feature/MypageFeature/Sources/Data/MemberRepositoryImpl.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/Data/MemberRepositoryImpl.swift
@@ -10,6 +10,7 @@ import CoreNetwork
 
 protocol MemberRepository {
     func getStudentInfo() async throws -> SearchStudentInfoEntity
+    func deleteMember() async throws -> Void
     func putRegisterStudentId(idCardImage: Data, name: String, studentNumber: String) async throws -> Void
     func deleteStudentId() async throws -> Void
 }
@@ -23,6 +24,10 @@ struct MemberRepositoryImpl: MemberRepository {
     func getStudentInfo() async throws -> SearchStudentInfoEntity {
         let dto: SearchStudentInfoResponseDTO = try await networkManager.request(MemberAPIEndpoint.getStudentId)
         return dto.toEntity()
+    }
+    
+    func deleteMember() async throws -> Void {
+        let _: EmptyResponseDTO = try await networkManager.request(MemberAPIEndpoint.deleteMemeber)
     }
     
     func putRegisterStudentId(idCardImage: Data, name: String, studentNumber: String) async throws -> Void {

--- a/Terbuck/Feature/MypageFeature/Sources/Domain/DeleteMemberUseCase.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/Domain/DeleteMemberUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  DeleteMemberUseCase.swift
+//  MypageFeature
+//
+//  Created by ParkJunHyuk on 6/19/25.
+//
+
+import Foundation
+
+public protocol DeleteMemberUseCase {
+    func execute() async throws -> Void
+}
+
+public struct DeleteMemberUseCaseImpl: DeleteMemberUseCase {
+    let repository: MemberRepository
+    
+    public func execute() async throws -> Void {
+        try await repository.deleteMember()
+    }
+}

--- a/Terbuck/Feature/MypageFeature/Sources/Domain/SearchStudentInfoUseCase.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/Domain/SearchStudentInfoUseCase.swift
@@ -20,10 +20,10 @@ public struct SearchStudentInfoUseCaseImpl: SearchStudentInfoUseCase {
         
         return UserInfoModel(
             userName: entity.studentName,
-            studentId: entity.studentNum,
-            university: UserDefaultsManager.shared.string(for: .university) ?? "정보 없음",
-            isAuthenticated: true,
-            imageUrl: entity.imageUrl
+            studentId: entity.studentNum ?? "",
+            university: entity.universityName,
+            isAuthenticated: entity.isAuth,
+            imageUrl: entity.imageUrl ?? ""
         )
     }
 }

--- a/Terbuck/Feature/MypageFeature/Sources/Factory/MypageFactoryImpl.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/Factory/MypageFactoryImpl.swift
@@ -18,7 +18,7 @@ public final class MypageFactoryImpl: MypageFactory {
 
     public func makeMypageViewController(coordinator: MypageCoordinator) -> UIViewController {
         let viewModel = MypageViewModel(
-            searchStudentInfoUseCase: SearchStudentInfoUseCaseImpl(repository: MemberRepositoryImpl())
+            searchStudentInfoUseCase: SearchStudentInfoUseCaseImpl(repository: MemberRepositoryImpl()), deleteMemberUseCase: DeleteMemberUseCaseImpl(repository: MemberRepositoryImpl())
         )
         
         return MypageViewController(

--- a/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
@@ -27,6 +27,7 @@ public final class MypageViewController: UIViewController {
     private let selectedCellSubject = PassthroughSubject<(section: MyPageType, index: Int), Never>()
     private let viewLifeCycleSubject = PassthroughSubject<ViewLifeCycleEvent, Never>()
     private var logoutButtonSubject = PassthroughSubject<Void, Never>()
+    private var withdrawButtonSubject = PassthroughSubject<Void, Never>()
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - UI Properties
@@ -81,7 +82,8 @@ private extension MypageViewController {
         let input = MypageViewModel.Input(
             viewLifeCycleEventAction: viewLifeCycleSubject.eraseToAnyPublisher(),
             selectedCell: selectedCellSubject.eraseToAnyPublisher(),
-            logoutButtonTapped: logoutButtonSubject.eraseToAnyPublisher()
+            logoutButtonTapped: logoutButtonSubject.eraseToAnyPublisher(),
+            withdrawButtonTapped: withdrawButtonSubject.eraseToAnyPublisher()
         )
         
         let output = mypageViewModel.transform(input: input)
@@ -136,7 +138,9 @@ private extension MypageViewController {
                         subTitle: "탈퇴 회원의 정보는 완전히 삭제되며\n터벅을 떠나면 회원가입부터 다시 해야해요",
                         leftButton: TerbuckBottomButton(type: .cancel),
                         rightButton: TerbuckBottomButton(type: .draw),
-                        rightButtonHandler: {}
+                        rightButtonHandler: {
+                            self?.withdrawButtonSubject.send()
+                        }
                     )
                 default:
                     break
@@ -165,6 +169,14 @@ private extension MypageViewController {
             }
             .store(in: &cancellables)
         
+        output.withdrawResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] result in
+                if result {
+                    self?.coordinator?.moveLoginFlow()
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/Terbuck/Feature/StoreFeature/Sources/Cell/StoreListModelCollectionViewCell.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Cell/StoreListModelCollectionViewCell.swift
@@ -84,6 +84,7 @@ private extension StoreListModelCollectionViewCell {
         storeNameLabel.do {
             $0.font = DesignSystem.Font.uiFont(.textSemi16)
             $0.textColor =  DesignSystem.Color.uiColor(.terbuckBlack50)
+            $0.numberOfLines = 2
         }
         
         storeAddressLabel.do {

--- a/Terbuck/Feature/StoreFeature/Sources/Coordinator/StoreCoordinator.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Coordinator/StoreCoordinator.swift
@@ -70,7 +70,13 @@ extension StoreCoordinator: StudentIDCardFlowDelegate {
     }
     
     public func registerStudentID() {
+        let viewModel = RegisterStudentCardViewModel(
+            registerStudentIDUseCase: RegisterStudentIDUseCaseImpl(repository: RegisterRepositoryImpl())
+        )
         
+        let registerStudentIDCardVC = RegisterStudentCardViewController(viewModel: viewModel)
+        registerStudentIDCardVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(registerStudentIDCardVC, animated: true)
     }
     
     public func dismissAuthStudentID() {

--- a/Terbuck/Feature/StoreFeature/Sources/Data/Entity/SearchDetailStoreEntity.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Data/Entity/SearchDetailStoreEntity.swift
@@ -14,12 +14,17 @@ public struct SearchDetailStoreEntity {
     let storeImageURL: [String]
     let address: String
     let benefitCount: Int
-    let benefitList: [SearchDetailStroeBenefitData]
+    let benefitList: [SearchDetailStoreBenefitData]
+    let usagesList: [SearchDetailStoreUsagesData]
 }
 
-public struct SearchDetailStroeBenefitData {
+public struct SearchDetailStoreBenefitData {
     let title: String
     let detailList: [String]
+}
+
+public struct SearchDetailStoreUsagesData {
+    let usagesTitle: String
 }
 
 extension SearchStoreDetailResponseDTO {
@@ -31,8 +36,9 @@ extension SearchStoreDetailResponseDTO {
             address: address,
             benefitCount: benefitCount,
             benefitList: benefitList.map {
-                SearchDetailStroeBenefitData(title: $0.title, detailList: $0.detailList)
-            }
+                SearchDetailStoreBenefitData(title: $0.title, detailList: $0.detailList)
+            },
+            usagesList: usagesList.map { SearchDetailStoreUsagesData(usagesTitle: $0.introduction) }
         )
     }
 }

--- a/Terbuck/Feature/StoreFeature/Sources/Domain/SearchDetailStoreUseCase.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Domain/SearchDetailStoreUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreNetwork
 
 public protocol SearchDetailStoreUseCase {
-    func execute(storeId: Int) async throws -> (DetailStoreHeaderModel, [DetailStoreImageModel]?, [DetailStoreBenefitModel], String)
+    func execute(storeId: Int) async throws -> (DetailStoreHeaderModel, [DetailStoreImageModel]?, [DetailStoreBenefitModel], String, [String])
 }
 
 public struct SearchDetailStoreUseCaseImpl: SearchDetailStoreUseCase {
@@ -19,7 +19,7 @@ public struct SearchDetailStoreUseCaseImpl: SearchDetailStoreUseCase {
         self.repository = repository
     }
 
-    public func execute(storeId: Int) async throws -> (DetailStoreHeaderModel, [DetailStoreImageModel]?, [DetailStoreBenefitModel], String){
+    public func execute(storeId: Int) async throws -> (DetailStoreHeaderModel, [DetailStoreImageModel]?, [DetailStoreBenefitModel], String,  [String]){
         let entity = try await repository.getSearchDetailStore(storeId: storeId)
         
         return convertToModel(entity)
@@ -27,7 +27,7 @@ public struct SearchDetailStoreUseCaseImpl: SearchDetailStoreUseCase {
 }
 
 extension SearchDetailStoreUseCaseImpl {
-    func convertToModel(_ entity: SearchDetailStoreEntity) -> (DetailStoreHeaderModel, [DetailStoreImageModel]?, [DetailStoreBenefitModel], String) {
+    func convertToModel(_ entity: SearchDetailStoreEntity) -> (DetailStoreHeaderModel, [DetailStoreImageModel]?, [DetailStoreBenefitModel], String, [String]) {
         
         let headerModel = DetailStoreHeaderModel(storeName: entity.storeName, storeAddress: entity.address)
         
@@ -35,10 +35,14 @@ extension SearchDetailStoreUseCaseImpl {
             DetailStoreImageModel(DetailStoreimageURL: $0)
         }
         
+        let useagesListModel = entity.usagesList.map {
+            $0.usagesTitle
+        }
+        
         let contentModel = entity.benefitList.map {
             DetailStoreBenefitModel(benefitTitle: $0.title, detailList: $0.detailList)
         }
         
-        return (headerModel, imageModel, contentModel, entity.storeURL)
+        return (headerModel, imageModel, contentModel, entity.storeURL, useagesListModel)
     }
 }

--- a/Terbuck/Feature/StoreFeature/Sources/View/DetailStoreInfoView.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/View/DetailStoreInfoView.swift
@@ -68,19 +68,12 @@ private extension DetailStoreInfoView {
     func benefitsSection() -> some View {
         VStack {
             if let benefitItem = viewModel.sectionData[.benefit], case .storeBenefit(let models) = benefitItem {
-                BenefitSectionView(benefitModel: models)
+                benefitSectionView(benefitModel: models, storeUsagesList: viewModel.storeUsagesList)
             }
         }
     }
-}
-
-
-
-struct BenefitSectionView: View {
     
-    let benefitModel: [DetailStoreBenefitModel]
-    
-    var body: some View {
+    func benefitSectionView(benefitModel: [DetailStoreBenefitModel], storeUsagesList: [String]) -> some View {
         VStack(alignment: .leading,spacing: 0) {
             HStack(spacing: 4) {
                 Image(uiImage: .selectStoreIcon)
@@ -88,6 +81,19 @@ struct BenefitSectionView: View {
                 Text("혜택 \(benefitModel.count)가지")
                     .font(DesignSystem.Font.swiftUIFont(.textSemi18))
                     .foregroundStyle(DesignSystem.Color.swiftUIColor(.terbuckBlack50))
+                
+                Spacer()
+                
+                if !storeUsagesList.isEmpty {
+                    Button(action: {
+                        viewModel.isUseagesListModal = true
+                    }) {
+                        Text("이용방법")
+                            .font(DesignSystem.Font.swiftUIFont(.textSemi14))
+                            .foregroundStyle(DesignSystem.Color.swiftUIColor(.terbuckBlack10))
+                    }
+                    .padding(.trailing, 5)
+                }
             }
             .padding(.vertical, 15)
             .padding(.bottom, 3)

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
@@ -54,6 +54,8 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
         setupLayout()
         setupDelegate()
         
+        ToastManager.shared.showToast(from: self, type: .moreBenefit)
+        
         Task {
             await detailStoreViewModel.fetchDetailStoreBenefitData()
         }
@@ -62,7 +64,19 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        ToastManager.shared.showToast(from: self, type: .moreBenefit)
+        detailStoreViewModel.onUseagesListModalChanged = { [weak self] isPresented in
+            if isPresented {
+                self?.showConfirmAlert(
+                    mainTitle: "이용방법",
+                    subTitle: self?.detailStoreViewModel.storeUsagesList.joined(separator: "\n"),
+                    centerButton: TerbuckBottomButton(type: .close(type: .alert), isEnabled: true),
+                    centerButtonHandler: {
+                        self?.dismiss(animated: false)
+                        self?.detailStoreViewModel.isUseagesListModal = false
+                    }
+                )
+            }
+        }
     }
     
     public override func viewDidLayoutSubviews() {
@@ -95,7 +109,9 @@ private extension DetailStoreInfoViewController {
             if UserDefaultsManager.shared.bool(for: .isStudentIDAuthenticated) {
                 self.coordinator?.showAuthStudentID()
             } else {
-                ToastManager.shared.showToast(from: self, type: .notAuthorized)
+                ToastManager.shared.showToast(from: self, type: .notAuthorized(type: .detailStore)) {
+                    self.coordinator?.registerStudentID()
+                }
             }
         }
     }

--- a/Terbuck/Feature/StoreFeature/Sources/ViewModel/DetailStoreInfoViewModel.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewModel/DetailStoreInfoViewModel.swift
@@ -31,6 +31,16 @@ public final class DetailStoreInfoViewModel: PreviewImageDisplayable {
     public var selectImageData: PreviewImageModel?
     
     public var storeURL: String?
+    public var storeUsagesList = [String]()
+    
+    public var isUseagesListModal = false {
+        didSet {
+            onUseagesListModalChanged?(isUseagesListModal)
+        }
+    }
+
+    public var onUseagesListModalChanged: ((Bool) -> Void)?
+    
     private let searchDetailStoreUseCase: SearchDetailStoreUseCase
     private let storeId: Int
     
@@ -87,6 +97,7 @@ private extension DetailStoreInfoViewModel {
             let result = try await self.searchDetailStoreUseCase.execute(storeId: storeId)
             
             storeURL = result.3
+            storeUsagesList = result.4
             
             return (result.0, result.1, result.2)
         } catch (let error) {

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/UniversityViewModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/UniversityViewModel.swift
@@ -95,7 +95,10 @@ public class UniversityViewModel {
                 
                 if let _ = self.signupUseCase, let universityName = self.universityName {
                     return self.signupPublisher(universityName)
-                        .map { _ in true }
+                        .map { _ in
+                            UserDefaultsManager.shared.set(universityName, for: .university)
+                            return true
+                        }
                         .catch { _ in Just(false) }
                         .eraseToAnyPublisher()
                 }

--- a/Terbuck/Project.swift
+++ b/Terbuck/Project.swift
@@ -54,6 +54,9 @@ let project = Project(
                       "kakaokompassauth",
                       "kakaolink"
                     ],
+                    "UIBackgroundModes": [
+                        "remote-notification"
+                    ],
                     "UIApplicationSceneManifest": [
                         "UIApplicationSupportsMultipleScenes": true,
                         "UISceneConfigurations": [
@@ -69,6 +72,7 @@ let project = Project(
             ),
             sources: ["Terbuck/Sources/**"],
             resources: ["Terbuck/Resources/**"],
+            entitlements: .file(path: "Terbuck/Terbuck.entitlements"),
             dependencies: [
                 .external(name: "FirebaseMessaging"),
                 .project(target: "Resource", path: "Resource"),

--- a/Terbuck/Terbuck/Sources/AppDelegate.swift
+++ b/Terbuck/Terbuck/Sources/AppDelegate.swift
@@ -19,7 +19,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // MARK: - 카카오 로그인 설정
         
-        print("설정", Config.kakaoNativeAppKey)
         KakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
         
         if isFirstLaunchAfterInstall() {

--- a/Terbuck/Terbuck/Terbuck.entitlements.swift
+++ b/Terbuck/Terbuck/Terbuck.entitlements.swift
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.usernotifications.filtering</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #27 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 애플 로그인 시 반환 받는 이름을 성+이름 으로 변경
- 회원 학생증 조회 API 수정 반영 ( 대학교 이름 추가 )
- 회원 탈퇴 API 구현 
- UI 변경 사항 반영 (제휴업체 이름, 주소 관련 설정 )
- 204 No Content 응답 시 빈 데이터 처리 추가

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 👨🏻‍🎓 회원 학생증 조회 API 변경사항

기존 회원 학생증 조회 API 응답에는 대학교 이름 정보가 포함되어 있지 않았습니다.
이로 인해 사용자가 재로그인하거나 앱 삭제 후 재설치 후 로그인 시, 대학교명을 확인할 수 없어 앱 사용이 불가능한 문제가 있었습니다.

TestFlight 테스트 중에는 해당 문제를 임시로 회피하기 위해 앱 실행 시 대학교명을 더미 데이터로 주입하는 방식으로 테스트를 진행했으며, 해당 처리는 API 개선 이후 삭제된 상태입니다.

현재 API가 수정되어 대학교명 정보가 응답에 포함되므로 더미 데이터 주입 없이 정상적으로 대학교명을 표시할 수 있도록 반영하였습니다.

<br>

### ⚠️ 204 No Content 응답 시 빈 데이터 처리 추가

기존 `resultResponse` 메서드는 200번대 응답일 때 기본적으로 정상적인 body 데이터가 존재한다고 가정하고 디코딩을 시도하도록 설계되어 있으며 혹시 모를 빈 `body` 대응을 위해 `EmptyResponseDTO` 처리 로직도 포함되어 있습니다.

다만, `DELETE` 요청 등에서 서버가 명시적으로 204 상태 코드를 반환하는 경우에는 `body` 자체가 없는 것이 정상적인 응답입니다.
기존 로직에서는 `statusCode` 가 204일 때도 body 유무와 관계없이 디코딩을 시도하게 되어, 디코딩 실패 에러가 발생하는 문제가 있었습니다.

``` swift
public class APIClient {
    func resultResponse<T: Decodable>(data: Data?, response: URLResponse) throws -> T {
        // 204 No Content 대응
        if httpResponse.statusCode == 204 {
            if T.self == EmptyResponseDTO.self, let emptyResult = EmptyResponseDTO() as? T {
                print("📦 EmptyResponseDTO 반환")
                return emptyResult
            } else {
                throw NetworkError.noData
            }
        }
        
        // ...

        switch httpResponse.statusCode {
        case 200..<300:
            // ...
        default:
            // ...
        }
    }
}
```

상태코드가 204일 경우에는 `body` 가 없는 것이 정상이므로 별도 분기 처리하여 `EmptyResponseDTO` 를 반환하도록 보완하였습니다.
이를 통해 `DELETE` 요청 등에서 발생하던 디코딩 에러를 방지하고 안정적으로 빈 응답을 처리할 수 있도록 개선하였습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
