### PR TITLE
[Feat] #29 - 최근 검색어를 보여주는 로직 구현

### DIFF
--- a/Terbuck/Feature/MypageFeature/Sources/ViewModel/MypageViewModel.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/ViewModel/MypageViewModel.swift
@@ -245,7 +245,7 @@ private extension MypageViewModel {
             FileStorageManager.shared.delete(type: .studentIdCard)
         }
         
-        let _ = FileStorageManager.shared.save(data: imageData, type: .studentIdCard)
+        let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
     }
     
     func allDeleteMyData() {

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/RegisterStudentCardViewModel.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/RegisterStudentCardViewModel.swift
@@ -104,7 +104,7 @@ public final class RegisterStudentCardViewModel {
                         guard let imageData = self.studentImageData else { return }
                         
                         UserDefaultsManager.shared.set(true, for: .isStudentIDAuthenticated)
-                        let _ = FileStorageManager.shared.save(data: imageData, type: .studentIdCard)
+                        let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
                     })
                     .catch { _ in Just(false).eraseToAnyPublisher() }
                     .eraseToAnyPublisher()

--- a/Terbuck/Feature/StoreFeature/Sources/Cell/Search/CurrentSearchStoreCollectionViewCell.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Cell/Search/CurrentSearchStoreCollectionViewCell.swift
@@ -17,7 +17,8 @@ public final class CurrentSearchStoreCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    private var moreBenefitTapHandler: (() -> Void)?
+    private var deleteButtonHandler: ((CurrentSearchModel) -> Void)?
+    private var serachStoreData: CurrentSearchModel?
     
     // MARK: - UI Properties
 
@@ -42,8 +43,13 @@ public final class CurrentSearchStoreCollectionViewCell: UICollectionViewCell {
 // MARK: - Extensions
 
 public extension CurrentSearchStoreCollectionViewCell {
-    func configureCell(_ title: String) {
-        currentStoreNameLabel.text = title
+    func configureCell(_ serachData: CurrentSearchModel) {
+        serachStoreData = serachData
+        currentStoreNameLabel.text = serachData.storeName
+    }
+    
+    func configureButtonAction(action: @escaping (CurrentSearchModel) -> Void) {
+        deleteButtonHandler = action
     }
 }
 
@@ -55,6 +61,14 @@ private extension CurrentSearchStoreCollectionViewCell {
             $0.font = DesignSystem.Font.uiFont(.textRegular16)
             $0.textColor =  DesignSystem.Color.uiColor(.terbuckBlack50)
         }
+        
+        deleteButton.do {
+            let config = UIImage.SymbolConfiguration(pointSize: 16, weight: .regular)
+            let image = UIImage(systemName: "xmark", withConfiguration: config)
+            $0.setImage(image, for: .normal)
+            $0.tintColor = DesignSystem.Color.uiColor(.terbuckBlack10)
+            $0.addTarget(self, action: #selector(deleteButtonAction), for: .touchUpInside)
+        }
     }
     
     func setupHierarchy() {
@@ -63,17 +77,21 @@ private extension CurrentSearchStoreCollectionViewCell {
     
     func setupLayout() {
         currentStoreNameLabel.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(18)
+            $0.verticalEdges.equalToSuperview().inset(19)
             $0.leading.equalToSuperview().offset(30)
             $0.trailing.equalTo(deleteButton.snp.leading).inset(15)
-            $0.size.equalTo(88)
         }
         
         deleteButton.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(18)
+            $0.centerY.equalTo(currentStoreNameLabel)
             $0.trailing.equalToSuperview().inset(30)
-            $0.size.equalTo(16)
         }
+    }
+    
+    @objc
+    func deleteButtonAction() {
+        guard let serachStoreData else { return }
+        deleteButtonHandler?(serachStoreData)
     }
 }
 

--- a/Terbuck/Feature/StoreFeature/Sources/Cell/Search/CustomHeaderCollectionReusableView.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Cell/Search/CustomHeaderCollectionReusableView.swift
@@ -1,0 +1,58 @@
+//
+//  CustomHeaderCollectionReusableView.swift
+//  StoreFeature
+//
+//  Created by ParkJunHyuk on 6/20/25.
+//
+
+import UIKit
+
+import DesignSystem
+import Shared
+
+import SnapKit
+import Then
+
+final class CustomHeaderCollectionReusableView: UICollectionReusableView {
+    
+    // MARK: - UI Components
+
+    private let headerTitleLabel = UILabel()
+    
+    // MARK: - init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Private Extensions
+
+private extension CustomHeaderCollectionReusableView {
+    func setupStyle() {
+        headerTitleLabel.do {
+            $0.text = "최근 검색어"
+            $0.font = DesignSystem.Font.uiFont(.textSemi16)
+            $0.textColor = DesignSystem.Color.uiColor(.terbuckBlack50)
+        }
+    }
+    
+    func setupHierarchy() {
+        self.addSubviews(headerTitleLabel)
+    }
+    
+    func setupLayout() {
+        headerTitleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(25)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/Terbuck/Feature/StoreFeature/Sources/Model/CurrentSearchModel.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Model/CurrentSearchModel.swift
@@ -9,10 +9,8 @@ import Foundation
 
 import DesignSystem
 
-public struct CurrentSearchModel: Identifiable, Hashable {
-    public var id: String {
-        return "\(storeName)"
-    }
-    
+public struct CurrentSearchModel: Identifiable, Hashable, Codable {
+    public var id: Int
     let storeName: String
+    let searchDate: Date
 }

--- a/Terbuck/Shared/Sources/Manager/FileStorageManager.swift
+++ b/Terbuck/Shared/Sources/Manager/FileStorageManager.swift
@@ -7,8 +7,14 @@
 
 import Foundation
 
+public struct SearchKeywordModel: Codable {
+    public let keyword: String
+    public let date: Date
+}
+
 public enum FileType: String {
     case studentIdCard = "studentIdCard.jpg"
+    case recentSearchKeywords = "recentSearchKeywords.json"
 }
 
 public final class FileStorageManager {
@@ -19,7 +25,7 @@ public final class FileStorageManager {
 
     // MARK: - Save Data
     
-    public func save(data: Data, type: FileType) -> Bool {
+    public func saveData(data: Data, type: FileType) -> Bool {
         let url = getDocumentsDirectory().appendingPathComponent(type.rawValue)
         do {
             try data.write(to: url)
@@ -30,12 +36,41 @@ public final class FileStorageManager {
             return false
         }
     }
+    
+    // MARK: - Save Json
+    
+    public func saveJSON<T: Codable>(_ object: T, type: FileType) -> Bool {
+        let url = getDocumentsDirectory().appendingPathComponent(type.rawValue)
+        do {
+            let data = try JSONEncoder().encode(object)
+            try data.write(to: url)
+            print("📥 \(type.rawValue) save success")
+            return true
+        } catch {
+            print("❌ \(type.rawValue) save failed:", error)
+            return false
+        }
+    }
 
     // MARK: - Load Data
     
     public func load(type: FileType) -> Data? {
         let url = getDocumentsDirectory().appendingPathComponent(type.rawValue)
         return try? Data(contentsOf: url)
+    }
+    
+    // MARK: - Load Json
+    
+    public func loadJSON<T: Codable>(type: FileType, as typeOf: T.Type) -> T? {
+        let url = getDocumentsDirectory().appendingPathComponent(type.rawValue)
+        do {
+            let data = try Data(contentsOf: url)
+            let object = try JSONDecoder().decode(T.self, from: data)
+            return object
+        } catch {
+            print("❌ \(type.rawValue) load failed:", error)
+            return nil
+        }
     }
 
     // MARK: - Delete Data


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #29

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 최근 검색어 관련 CollectionView Header 추가
- 기존 `FileStorageManager` 에 `json` 파일을 자장할 수 있는 로직 추가
- `CurrentSearchModel` 에 최근 검색 날짜, 제휴업체 id 변수 추가

<br>

## 📸 스크린샷
|기능|최근 검색어 추가|최근 검색어 선택|최근 검색어 삭제|
|:--:|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/eb17fc4f-2b45-41a0-b749-6314daab0d9e" width ="250">|<img src = "https://github.com/user-attachments/assets/967e6b79-db06-4673-ba5f-35fe875faa4c" width ="250">|<img src = "https://github.com/user-attachments/assets/aec7c3fe-725c-4a8f-8deb-eb073da55605" width ="250">|


<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 📦 FileStorageManager에 JSON 저장/로딩 기능 추가 (saveJSON, loadJSON)

기존에 `Data` 단위 저장/불러오기만 가능했던 기능을 보완하여, `Codable` 객체를 바로 저장 및 읽을 수 있도록 `saveJSON`, `loadJSON` 메서드 제공합니다.

#### 💾 저장 타입

``` Swift
public enum FileType: String {
    case studentIdCard = "studentIdCard.jpg" // 학생증 사진 저장
    case recentSearchKeywords = "recentSearchKeywords.json" // 최근 검색어 저장
}
```

#### 📥 저장 예시

``` Swift
let keywordModel = CurrentSearchModel(id: storeModel.id, storeName: storeModel.storeName, searchDate: Date())
let result = FileStorageManager.shared.saveJSON(keywordModel, type: .recentSearchKeywords)
```

#### 📤 불러오기 예시

``` Swift
if let loadedModel = FileStorageManager.shared.loadJSON(type: .recentSearchKeywords, as: [CurrentSearchModel].self) {
    print("불러온 제휴업체 이름:", loadedModel.storeName)
    print("불러온 date:", loadedModel.searchDate)
} else {
    print("불러오기 실패")
}
```

#### ❌ 삭제하기 예시

``` Swift
FileStorageManager.shared.delete(type: .recentSearchKeywords)
```



<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
