### PR TITLE
[Fix] #39 - 리젝 사항 문제 해결

### DIFF
--- a/Terbuck/Core/CoreAppleLogin/Sources/AppleLoginService.swift
+++ b/Terbuck/Core/CoreAppleLogin/Sources/AppleLoginService.swift
@@ -53,8 +53,7 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
 
    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
        AppLogger.log("Apple 로그인 실패: \(error.localizedDescription)", .error, .service)
-               continuation?.resume(throwing: error)
-       continuation?.resume(throwing: error)
+           continuation?.resume(throwing: error)
    }
 }
 

--- a/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
@@ -219,6 +219,7 @@ private extension HomeViewController {
                 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     ToastManager.shared.showToast(from: self, type: .alarmStudentCard) {
+                        MixpanelManager.shared.track(eventType: TrackEventType.Home.alarmButtonInToastMessage)
                         self.coordinator?.showAlarmSetting()
                     }
                 }

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreMapViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreMapViewController.swift
@@ -90,8 +90,9 @@ final class StoreMapViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        AppLogger.log("StoreMapViewController viewWillAppear", .info, .ui)
+        
         storeMapViewModel.viewLifeCycleSubject.send(.viewWillAppear)
-        print("StoreMapViewController viewWillAppear")
         
         switch storeMapViewModel.storeMapTypeSubject.value {
         case .search:
@@ -140,6 +141,7 @@ private extension StoreMapViewController {
         storeMapViewModel.storeItemsTappedResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] itemId in
+                MixpanelManager.shared.track(eventType: TrackEventType.TerbuckMap.storelistDataTapped)
                 self?.coordinator?.showDetailStoreInfo(storeId: itemId)
             }
             .store(in: &cancellables)
@@ -347,9 +349,6 @@ private extension StoreMapViewController {
             let tapGesture = UITapGestureRecognizer(target: self, action: #selector(storeBottomTapped))
             $0.addGestureRecognizer(tapGesture)
             $0.isUserInteractionEnabled = true
-        }
-        
-        storeInfoBottomView.do {
             $0.isHidden = true
         }
     }
@@ -432,6 +431,7 @@ private extension StoreMapViewController {
     
     @objc func storeBottomTapped() {
         guard let store = storeMapViewModel.searchResultStoreTappedSubject.value else { return }
+        MixpanelManager.shared.track(eventType: TrackEventType.TerbuckMap.storeMapDataTapped)
         self.coordinator?.showDetailStoreInfo(storeId: store.id)
     }
     

--- a/Terbuck/Project.swift
+++ b/Terbuck/Project.swift
@@ -43,7 +43,7 @@ let project = Project(
                     "NMFClientId": "$(NMFClientId)",
                     "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)",
                     "MIXPANEL_USER_KEY": "$(MIXPANEL_USER_KEY)",
-                    "NSLocationWhenInUseUsageDescription": "현재 위치를 사용하려면 허용해주세요.",
+                    "NSLocationWhenInUseUsageDescription": "현재 위치를 기반으로 주변 제휴 업체를 보여드리기 위해 위치 정보가 필요합니다.",
                     "CFBundleURLTypes": [
                         [
                             "CFBundleURLSchemes": [ "kakao$(KAKAO_NATIVE_APP_KEY)" ]

--- a/Terbuck/Shared/Sources/Manager/MixpanelManager.swift
+++ b/Terbuck/Shared/Sources/Manager/MixpanelManager.swift
@@ -85,6 +85,8 @@ public struct TrackEventType {
         public static let myLocationButtonTapped = "click_map_gps"
         public static let searchBarTapped = "click_map_searchbar"
         public static let searchResultTapped = "click_map_search_result"
+        public static let storelistDataTapped = "move_list_to_detail"
+        public static let storeMapDataTapped = "move_map_to_detail"
     }
     
     public struct DetailStore {
@@ -105,5 +107,10 @@ public struct TrackEventType {
         public static let logoutConfirmButtonTapped = "click_mypage_logout_confirm"
         public static let signoutMenuButtonTapped = "click_mypage_signout"
         public static let signoutConfirmButtonTapped = "click_mypage_signout_confirm"
+    }
+    
+    public struct Alarm {
+        public static let authedPushAlarmTapped = "click_push_alarm_student_card"
+        public static let pushAlarmTapped = "click_push_alarm"
     }
 }

--- a/Terbuck/Terbuck/Sources/AppDelegate.swift
+++ b/Terbuck/Terbuck/Sources/AppDelegate.swift
@@ -92,9 +92,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         
-        let userInfo = notification.request.content.userInfo
+        let content = notification.request.content
+        let title = content.title
+        let body = content.body
+        let userInfo = content.userInfo
+
         AppLogger.log("포그라운드 알림 수신", .info, .default)
-        AppLogger.log("수신 데이터: \(userInfo)", .debug, .default)
+        AppLogger.log("제목: \(title)", .debug, .default)
+        AppLogger.log("내용: \(body)", .debug, .default)
+        AppLogger.log("userInfo: \(userInfo)", .debug, .default)
+
         completionHandler([.banner, .badge, .sound])
     }
     
@@ -102,6 +109,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        MixpanelManager.shared.track(eventType: TrackEventType.Alarm.authedPushAlarmTapped)
+        
         // 여기서 알림 클릭 처리
         completionHandler()
     }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #39 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 사용자 분석 툴 Mixpanel 에 대한 새로운 타입 추가 및 적용
- 위치 권한 요청 문구 개선 ( 어떤 기능에서 사용하는지? )
- 로그인 관련 Combine 로직 변경

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 🎯 LoginViewModel의 Combine 스트림 로직 안정성 강화

> App Store Review Guideline 2.1 (Performance: App Completeness) 를 위반하여 다음과 같은 문제해결을 진행했습니다.

LoginViewModel 내부의 Combine 스트림 처리 로직에서 발견된 오류를 수정하고, 코드의 안정성과 가독성을 높이기 위해 리팩토링을 진행했습니다. 로그인 실패 시 전체 스트림이 종료되는 문제를 해결하고, 보다 예측 가능하게 동작하도록 데이터 흐름을 개선한 것입니다.

---

#### ⚠️ 문제 진단

기존 LoginViewModel 에는 Combine 로직에 2가지 문제점이 존재했습니다. 

1. `flatMap` 연산자의 타입 불일치 

첫번째 비동기 작업 (appleServiceLoginPublisher - 소셜로그인 로직) 의 `Failure` 타입이 `LoginError` 였지만 `FlatMap` 내부에서 연결하려던 두번째 비동기 작업(appleServerLoginPublisher - 서버 로그인 로직) 의 `Failure` 타입은 `Never` 였습니다. 

2. `Publishers.Merge` 의 조기 종료 문제 (핵심 원인)

`Merge` 는 여러 스트림을 하나로 합칠 때, 그중 하나의 스트림이라도 `.failure` 이벤트를 받고 종료되면, 병합된 전체 스트림을 즉시 종료시킵니다. 

카카오, 애플 로그인 둘중 하나라도 실패를 한다면 Publishers.Merge 가 실패를 감지하고 merged 스트림 전체를 종료 시키기 때문에 이후 다른 로그인을 시도해도 이미 스트림이 죽어있어 아무런 반응도 하지 않는 버그가 발생하게 되었습니다. 

---

#### 💡 해결방안 

1. 서버 로그인 Publisher 반환 타입 수정 

- `flatMap` 체인이 올바르게 동작하도록 모든 비동기 작업의 `Failure` 타입을 `LoginError` 로 통일 했습니다. 
- apple & kakao `ServerLoginPublisher` 함수가 성공 시에는 `LoginResultModel` 을, 실패 시에는 `LoginError` 를 방출하도록 변경했습니다.  (기존은 `Result` 타입을 반환)

2. `Result` 를 이용한 스트림 생명주기 관리

- `Publishers.Merge` 의 조기 종료 문제를 해결하기 위해 스트림을 종료시키는 `.failure` 이벤트를 스트림이 계속 살아있게 만드는 `.success` 값으로 변환하는 패턴을 적용했습니다.
- 성공한 결과(LoginResultModel)는 `.map { .success($0) }` 을 통해 Result.success 값으로 포장했습니다.
- 실패한 이벤트(LoginError)는 `.catch { Just(.failure($0)) }` 를 통해 Result.failure 값으로 포장했습니다.

3. flatMap을 이용한 최종 에러 처리

- `merged` 스트림을 통해 전달된 `Result` 값을 `flatMap` 내부에서 `switch` 문으로 안전하게 열어봅니다.
- 이때 값이 .failure인 경우에만 Fail(error:) Publisher를 사용해 의도적으로 스트림을 종료시키고, 최종적으로 View Controller에 에러를 전달합니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
