### PR TITLE
[Feat] #43 - SearchBar 관련 UI 수정

### DIFF
--- a/Terbuck/DesignSystem/Sources/ToastMessage/ToastManager.swift
+++ b/Terbuck/DesignSystem/Sources/ToastMessage/ToastManager.swift
@@ -45,7 +45,7 @@ public final class ToastManager {
             toastView.transform = .identity
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             UIView.animate(withDuration: 0.3, animations: {
                 toastView.alpha = 0
                 toastView.transform = CGAffineTransform(translationX: 0, y: 20)

--- a/Terbuck/DesignSystem/Sources/ToastMessage/ToastManager.swift
+++ b/Terbuck/DesignSystem/Sources/ToastMessage/ToastManager.swift
@@ -10,6 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
+private enum Constant {
+    static let displayDuration: TimeInterval = 2.0
+}
+
 public final class ToastManager {
     
     public static let shared = ToastManager()
@@ -45,7 +49,7 @@ public final class ToastManager {
             toastView.transform = .identity
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constant.displayDuration) {
             UIView.animate(withDuration: 0.3, animations: {
                 toastView.alpha = 0
                 toastView.transform = CGAffineTransform(translationX: 0, y: 20)

--- a/Terbuck/Feature/AuthFeature/Sources/ViewModel/TermsOfServiceViewModel.swift
+++ b/Terbuck/Feature/AuthFeature/Sources/ViewModel/TermsOfServiceViewModel.swift
@@ -41,11 +41,7 @@ public class TermsOfServiceViewModel {
     
     // MARK: - Init
     
-    public init(
-        
-    ) {
-        
-    }
+    public init() { }
     
     // MARK: - Public methods
     

--- a/Terbuck/Feature/StoreFeature/Sources/View/SearchBarView.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/View/SearchBarView.swift
@@ -23,7 +23,6 @@ public final class SearchBarView: UIView {
     
     private var type: SearchBarType {
         didSet {
-            setupStyle()
             updateLayout()
         }
     }
@@ -54,6 +53,7 @@ public final class SearchBarView: UIView {
     
     public func configureSearchType(_ type: SearchBarType) {
         self.type = type
+        placeholderLabel.text = "우리 대학 제휴 업체는?"
     }
     
     public func configureSearchResultType(storeName: String) {
@@ -77,7 +77,6 @@ private extension SearchBarView {
             $0.image = image
             $0.tintColor = DesignSystem.Color.uiColor(.terbuckBlack30)
             $0.contentMode = .scaleAspectFit
-            $0.isHidden = type == .search ? true : false
         }
         
         rightSearchImageView.do {
@@ -116,20 +115,6 @@ private extension SearchBarView {
             $0.size.equalTo(24)
         }
         
-        if type == .search {
-            placeholderLabel.snp.makeConstraints {
-                $0.verticalEdges.equalToSuperview().inset(14.5)
-                $0.leading.equalToSuperview().offset(12)
-                $0.trailing.equalTo(rightSearchImageView.snp.leading).inset(5)
-            }
-        } else {
-            placeholderLabel.snp.makeConstraints {
-                $0.verticalEdges.equalToSuperview().inset(14.5)
-                $0.leading.equalTo(leftMenuImageView.snp.trailing).offset(12)
-                $0.trailing.equalTo(rightSearchImageView.snp.leading).inset(5)
-            }
-        }
-        
         rightSearchImageView.snp.makeConstraints {
             $0.verticalEdges.equalToSuperview().inset(12)
             $0.trailing.equalToSuperview().inset(12)
@@ -138,6 +123,10 @@ private extension SearchBarView {
     }
     
     func updateLayout() {
+        leftMenuImageView.isHidden = type == .search ? true : false
+        
+        placeholderLabel.textColor = DesignSystem.Color.uiColor(type == .search ? .terbuckBlack10 : .terbuckBlack50)
+        
         placeholderLabel.snp.remakeConstraints {
             $0.verticalEdges.equalToSuperview().inset(14.5)
             $0.trailing.equalTo(rightSearchImageView.snp.leading).inset(5)

--- a/Terbuck/Feature/StoreFeature/Sources/View/SearchBarView.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/View/SearchBarView.swift
@@ -24,6 +24,7 @@ public final class SearchBarView: UIView {
     private var type: SearchBarType {
         didSet {
             setupStyle()
+            updateLayout()
         }
     }
     
@@ -71,15 +72,12 @@ private extension SearchBarView {
         }
         
         leftMenuImageView.do {
-            if type == .search {
-                $0.image = .line3
-            } else {
-                let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)
-                let image = UIImage(systemName: "chevron.left", withConfiguration: config)
-                $0.image = image
-                $0.tintColor = DesignSystem.Color.uiColor(.terbuckBlack30)
-            }
+            let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)
+            let image = UIImage(systemName: "chevron.left", withConfiguration: config)
+            $0.image = image
+            $0.tintColor = DesignSystem.Color.uiColor(.terbuckBlack30)
             $0.contentMode = .scaleAspectFit
+            $0.isHidden = type == .search ? true : false
         }
         
         rightSearchImageView.do {
@@ -118,16 +116,37 @@ private extension SearchBarView {
             $0.size.equalTo(24)
         }
         
-        placeholderLabel.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(14.5)
-            $0.leading.equalTo(leftMenuImageView.snp.trailing).offset(12)
-            $0.trailing.equalTo(rightSearchImageView.snp.leading).inset(5)
+        if type == .search {
+            placeholderLabel.snp.makeConstraints {
+                $0.verticalEdges.equalToSuperview().inset(14.5)
+                $0.leading.equalToSuperview().offset(12)
+                $0.trailing.equalTo(rightSearchImageView.snp.leading).inset(5)
+            }
+        } else {
+            placeholderLabel.snp.makeConstraints {
+                $0.verticalEdges.equalToSuperview().inset(14.5)
+                $0.leading.equalTo(leftMenuImageView.snp.trailing).offset(12)
+                $0.trailing.equalTo(rightSearchImageView.snp.leading).inset(5)
+            }
         }
         
         rightSearchImageView.snp.makeConstraints {
             $0.verticalEdges.equalToSuperview().inset(12)
             $0.trailing.equalToSuperview().inset(12)
             $0.size.equalTo(24)
+        }
+    }
+    
+    func updateLayout() {
+        placeholderLabel.snp.remakeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(14.5)
+            $0.trailing.equalTo(rightSearchImageView.snp.leading).inset(5)
+            
+            if type == .search {
+                $0.leading.equalToSuperview().offset(12)
+            } else {
+                $0.leading.equalTo(leftMenuImageView.snp.trailing).offset(12)
+            }
         }
     }
 }
@@ -137,6 +156,9 @@ import SwiftUI
 
 #Preview("SearchBarView") {
     SearchBarView(type: .search)
+        .showPreview()
+    
+    SearchBarView(type: .searchResult)
         .showPreview()
 }
 #endif

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreListModalViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreListModalViewController.swift
@@ -246,6 +246,13 @@ private extension StoreListModalViewController {
     func bindViewModel() {
         storeMapViewModel.viewLifeCycleSubject.send(.viewDidLoad)
         
+        storeMapViewModel.initStoreDataSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] items in
+                self?.applyStoreSnapshot(items: items)
+            }
+            .store(in: &cancellables)
+        
         storeMapViewModel.storeListSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] items in

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreMapViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreMapViewController.swift
@@ -114,7 +114,7 @@ final class StoreMapViewController: UIViewController {
 
 private extension StoreMapViewController {
     func bindViewModel() {
-        storeMapViewModel.storeListSubject
+        storeMapViewModel.initStoreDataSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] items in
                 guard let self else { return }
@@ -123,6 +123,19 @@ private extension StoreMapViewController {
                 let type = CategoryType.allCases[index]
                 
                 self.initStoreMarkers(with: items)
+                self.filterToCategoryTypeMarker(category: type)
+                self.fitAllMarkers(currentCategoryMarkers, in: mapView, currentIndex: self.storeMapViewModel.currentSnapIndex.value)
+            }
+            .store(in: &cancellables)
+        
+        storeMapViewModel.storeListSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] items in
+                guard let self else { return }
+                
+                let index = storeMapViewModel.storeCategoryPublisher.value
+                let type = CategoryType.allCases[index]
+                
                 self.filterToCategoryTypeMarker(category: type)
                 self.fitAllMarkers(currentCategoryMarkers, in: mapView, currentIndex: self.storeMapViewModel.currentSnapIndex.value)
             }
@@ -267,7 +280,11 @@ private extension StoreMapViewController {
             return storedStore.id == store.id
         }
         
-        storeMarker?.mapView = mapView
+        if let storeMarker {
+            selectedMarker = storeMarker
+            currentCategoryMarkers.append(storeMarker)
+            makeMakerInMapView()
+        }
     }
 
     func fitAllMarkers(_ markers: [NMFMarker], in mapView: NMFMapView, currentIndex: Int) {

--- a/Terbuck/Feature/StoreFeature/Sources/ViewModel/StoreMapViewModel.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewModel/StoreMapViewModel.swift
@@ -11,6 +11,8 @@ import UIKit
 import DesignSystem
 import Shared
 
+import NMapsMap
+
 enum StoreMapError: LocalizedError, Equatable {
     case studentInfoFailed
     case unknown
@@ -51,6 +53,7 @@ public final class StoreMapViewModel {
     public let longitudeSubject = CurrentValueSubject<Double?, Never>(nil)
     public let currentSnapIndex = CurrentValueSubject<Int, Never>(1)
     public let storeSearchKeywordSubject = CurrentValueSubject<[CurrentSearchModel], Never>([])
+    public let currentCategoryMarkersSubject = CurrentValueSubject<[NMFMarker], Never>([])
     
     // MARK: - SearchStore Input Combine Publishers Properties
     
@@ -62,6 +65,7 @@ public final class StoreMapViewModel {
     
     // MARK: - Output Combine Publishers Properties
     
+    public let initStoreDataSubject = PassthroughSubject<[StoreListModel], Never>()
     public let storeListSubject = CurrentValueSubject<[StoreListModel], Never>([])
     public let categoryItemsSubject = CurrentValueSubject<[CategoryModel], Never>([])
     public let storeItemsTappedResult = PassthroughSubject<Int, Never>()
@@ -104,15 +108,16 @@ public final class StoreMapViewModel {
                 self?.updateCategorySelection(to: index)
             })
             .share()
-        
-        // ✅ 전체 카테고리일 경우: 서버 호출
-        let fetchPublisher = sharedPublisher
-            .filter { categoryIndex in categoryIndex == 0 }
-            .flatMap { [weak self] categoryIndex -> AnyPublisher<[StoreListModel], Never> in
-                guard let self else { return Empty().eraseToAnyPublisher() }
 
+        // 1️⃣ 전체 카테고리일 경우: 서버 호출 스트림
+        sharedPublisher
+            .filter { categoryIndex in categoryIndex == 0 }
+            .flatMap { [weak self] _ -> AnyPublisher<[StoreListModel], Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                
                 return self.getStoreDataPublisher(category: "", lat: latitude, lng: longitude)
                     .handleEvents(receiveCompletion: { [weak self] completion in
+                        
                         if case .failure(let error) = completion {
                             self?.storeMapErrorSubject.send(error)
                         }
@@ -120,30 +125,26 @@ public final class StoreMapViewModel {
                     .catch { _ in Just([]) }
                     .eraseToAnyPublisher()
             }
-        
-        // ✅ 특정 카테고리 선택시: 필터링만 수행
-        let filterPublisher = sharedPublisher
-            .filter { categoryIndex in categoryIndex != 0 }
-            .handleEvents(receiveOutput: { [weak self] categoryIndex in
-                self?.updateStoreList(to: categoryIndex)
-            })
-            .map { _ in [StoreListModel]() } // 빈 리스트로 데이터 방출
-
-        // ✅ 병합 후 처리
-        Publishers.Merge(fetchPublisher, filterPublisher)
             .sink { [weak self] storeList in
-                guard !storeList.isEmpty else { return }
                 self?.categoryStoreData.removeAll()
                 
                 storeList.forEach {
                     self?.cachedItems[$0.id] = $0
                     self?.categoryStoreData[$0.category, default: []].append($0)
                 }
-
-                self?.storeListSubject.send(storeList)
+                
+                self?.initStoreDataSubject.send(storeList)
             }
             .store(in: &cancellables)
-        
+
+        // 2️⃣ 특정 카테고리 선택시: 필터링 스트림
+        sharedPublisher
+            .filter { categoryIndex in categoryIndex != 0 }
+            .sink { [weak self] categoryIndex in
+                self?.updateStoreList(to: categoryIndex)
+            }
+            .store(in: &cancellables)
+       
         didSelectItemSubject
             .sink { [weak self] index in
                 guard let data = self?.storeListSubject.value[index] else { return }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #43 

<br>

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
- SearchBar 의 왼쪽 이미지 관련 수정
- 검색 시 현재 카테고리에 없는 마커가 표기되지 않는 문제 해결
- ToastMessage 의 지속 시간 변경 ( 3 -> 2s )

<br>

## 📸 스크린샷
|기능|변경 전|변경 후|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/6eba7d65-1c7c-4b66-9114-96567be72ecf" width ="250">|<img src = "https://github.com/user-attachments/assets/3da9790d-ae88-4140-bd73-5bb884ad7a95" width ="250">|
|GIF|<img src = "https://github.com/user-attachments/assets/3dae4323-8849-49c8-a1fb-c9ef8b285aef" width ="250">|<img src = "https://github.com/user-attachments/assets/017281ba-47e7-46a4-8e4a-63397eb664fc" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### Search Bar 좌측 이미지 수정

- search 상태 ( 지도 탐색 중 ) 일때 카테고리 아이콘을 제거 했습니다.

<br>

### 검색 시 현재 카테고리에 없는 마커가 표기되지 않는 문제 해결

- 지도 마커의 UI 상태가 현재 선택된 카테고리에만 종속되어 있었습니다.
- 전역 검색 결과에 포함된 다른 카테고리의 마커가 렌더링되지 않던 문제를 해결했습니다. 
- 이제 검색 시 필요한 모든 마커 정보를 참조하여 지도에 올바르게 표기합니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
