### PR TITLE
[Refactor] #47 - HomeViewModel 로직 개선

### DIFF
--- a/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
@@ -93,8 +93,6 @@ public final class HomeViewModel {
         
         selectedFilterSubject
             .handleEvents(receiveOutput: { type in
-                MixpanelManager.shared.track(eventType: TrackEventType.Home.eatingButtonTapped)
-                
                 switch type {
                 case .restaurent:
                     MixpanelManager.shared.track(eventType: TrackEventType.Home.eatingButtonTapped)
@@ -108,85 +106,18 @@ public final class HomeViewModel {
             .flatMap { [weak self] filter, location -> AnyPublisher<[HomeItem], Never> in
                 guard let self else { return Empty().eraseToAnyPublisher() }
                 
-                // 위치 인증 여부 확인
-                var isLocationAuthorized = false
-                
-                switch self.locationManager.authorizationStatus {
-                case .authorizedWhenInUse, .authorizedAlways:
-                    isLocationAuthorized = true
-                default:
-                    isLocationAuthorized = false
-                }
-                
                 switch filter {
-                case .restaurent:
-                    if isLocationAuthorized == false {
-                       // 권한 X : 위치 nil 로 호출
-                       return self.postNearStorePublisher(latitude: nil, longitude: nil)
-                           .handleEvents(receiveCompletion: { [weak self] completion in
-                               if case .failure(let error) = completion {
-                                   self?.homeErrorSubject.send(error)
-                               }
-                           })
-                           .map { stores in
-                               stores.map { filter == .restaurent ? HomeItem.restaurant($0) : HomeItem.convenient($0) }
-                           }
-                           .catch { _ in Empty() }
-                           .eraseToAnyPublisher()
-                   } else {
-                       // 권한 O : 위치 값 들어온 경우에만 호출
-                       guard let latitude = location.latitude, let longitude = location.longitude else {
-                           // 위치 값 아직 없음 → 빈 스트림 리턴
-                           return Empty().eraseToAnyPublisher()
-                       }
-                       
-                       return self.postNearStorePublisher(latitude: latitude, longitude: longitude)
-                           .handleEvents(receiveCompletion: { [weak self] completion in
-                               if case .failure(let error) = completion {
-                                   self?.homeErrorSubject.send(error)
-                               }
-                           })
-                           .map { stores in
-                               stores.map { filter == .restaurent ? HomeItem.restaurant($0) : HomeItem.convenient($0) }
-                           }
-                           .catch { _ in Empty() }
-                           .eraseToAnyPublisher()
-                   }
-                    
-                case .convenient:
-                    let location = myLocationSubject.value
-                    
-                    return self.postNearStorePublisher(latitude: location.latitude, longitude: location.longitude)
-                        .handleEvents(receiveCompletion: { [weak self] completion in
-                            if case .failure(let error) = completion {
-                                self?.homeErrorSubject.send(error)
-                            }
-                        })
-                        .map { stores in
-                            stores.map { HomeItem.convenient($0) }
-                        }
-                        .catch { _ in Empty() }
-                        .eraseToAnyPublisher()
-                    
+                case .restaurent, .convenient:
+                    return self.fetchStoreItems(for: filter, location: location)
                 case .partnership:
-                    return self.postPartnershipPublisher()
-                        .handleEvents(receiveCompletion: { [weak self] completion in
-                            if case .failure(let error) = completion {
-                                self?.homeErrorSubject.send(error)
-                            }
-                        })
-                        .map { partnerships in
-                            (partnerships ?? []).map { HomeItem.partnership($0) }
-                        }
-                        .catch { _ in Empty() }
-                        .eraseToAnyPublisher()
+                    return self.fetchPartnershipItems()
                 }
             }
             .sink { [weak self] items in
                 guard let self else { return }
-
+                
                 var sectionData: [HomeSection: [HomeItem]] = [:]
-
+                
                 for item in items {
                     switch item {
                     case .restaurant:
@@ -205,7 +136,7 @@ public final class HomeViewModel {
                         }
                     }
                 }
-
+                
                 self.sectionDataSubject.send(sectionData)
             }
             .store(in: &cancellables)
@@ -226,9 +157,75 @@ public extension HomeViewModel {
     }
 }
 
-// MARK: - Private API Extension
+// MARK: - Private Extension
 
 private extension HomeViewModel {
+    
+    // MARK: - High-Level Fetch Logic
+    
+    /// 필터 유형과 위치 정보에 따라 주변 상점 정보를 비동기적으로 가져와 `HomeItem` 배열로 변환합니다.
+    /// - Parameters:
+    ///   - filter: 상점 카테고리를 정의하는 `StoreFilterType` (예: .restaurent, .convenient).
+    ///   - location: 위도와 경도를 포함하는 튜플. 위치 권한이 없거나 아직 값을 받지 못한 경우 nil일 수 있습니다.
+    /// - Returns: `HomeItem`의 배열을 방출하는 `AnyPublisher`를 반환합니다. 에러가 발생하면 빈 배열을 방출합니다.
+    func fetchStoreItems(for filter: StoreFilterType, location: (latitude: Double?, longitude: Double?)) -> AnyPublisher<[HomeItem], Never> {
+        let isLocationAuthorized: Bool
+        
+        switch locationManager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            isLocationAuthorized = true
+        default:
+            isLocationAuthorized = false
+        }
+        
+        let publisher: AnyPublisher<[NearStoreModel], HomeError>
+        
+        if !isLocationAuthorized {
+            publisher = postNearStorePublisher(latitude: nil, longitude: nil)
+        } else {
+            guard let latitude = location.latitude, let longitude = location.longitude else {
+                return Empty().eraseToAnyPublisher()
+            }
+            
+            publisher = postNearStorePublisher(latitude: latitude, longitude: longitude)
+        }
+        
+        return publisher
+            .handleEvents(receiveCompletion: { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.homeErrorSubject.send(error)
+                }
+            })
+            .map { stores in
+                stores.map { filter == .restaurent ? HomeItem.restaurant($0) : HomeItem.convenient($0) }
+            }
+            .catch { _ in Just([]) }
+            .eraseToAnyPublisher()
+    }
+    
+    /// 제휴사 정보를 비동기적으로 가져와 `HomeItem` 배열로 변환합니다.
+    /// - Returns: `HomeItem`의 배열을 방출하는 `AnyPublisher`를 반환합니다. 에러가 발생하면 빈 배열을 방출합니다.
+    func fetchPartnershipItems() -> AnyPublisher<[HomeItem], Never> {
+        return postPartnershipPublisher()
+            .handleEvents(receiveCompletion: { [weak self] completion in
+                if case .failure(let error) = completion {
+                    self?.homeErrorSubject.send(error)
+                }
+            })
+            .map { partnerships in
+                partnerships.map { HomeItem.partnership($0) }
+            }
+            .catch { _ in Just([]) }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Low-Level API Publishers
+    
+    /// `SearchStoreUseCase`를 사용하여 서버에 주변 상점 정보 조회를 요청합니다.
+    /// - Parameters:
+    ///   - latitude: 검색 기준이 될 사용자의 현재 위도. `nil`일 경우 서버에서 기본 위치를 사용합니다.
+    ///   - longitude: 검색 기준이 될 사용자의 현재 경도. `nil`일 경우 서버에서 기본 위치를 사용합니다.
+    /// - Returns: API 응답으로 받은 `[NearStoreModel]` 배열을 방출하거나, 실패 시 `HomeError`를 방출하는 `AnyPublisher`를 반환합니다.
     func postNearStorePublisher(latitude: Double?, longitude: Double?) -> AnyPublisher<[NearStoreModel], HomeError> {
         return Future { [weak self] promise in
             guard let self else {
@@ -255,9 +252,10 @@ private extension HomeViewModel {
         .eraseToAnyPublisher()
     }
     
-    func postPartnershipPublisher() -> AnyPublisher<[PartnershipModel]?, HomeError> {
+    /// `SearchPartnershipUseCase`를 사용하여 서버에 일반 및 신규 제휴사 정보 조회를 요청합니다.
+    /// - Returns: API 응답으로 받은 `[PartnershipModel]` 배열을 방출하거나, 실패 시 `HomeError`를 방출하는 `AnyPublisher`를 반환합니다.
+    func postPartnershipPublisher() -> AnyPublisher<[PartnershipModel], HomeError> {
         return Future { [weak self] promise in
-            
             guard let self else {
                 promise(.failure(.unknown))
                 return
@@ -265,10 +263,11 @@ private extension HomeViewModel {
             
             Task {
                 do {
-                    let partnershipResult = try await self.searchPartnershipUseCase.searchExecute()
-                    let newPartnershipResult = try await self.searchPartnershipUseCase.newSearchExecute()
+                    async let partnershipResult = self.searchPartnershipUseCase.searchExecute()
+                    async let newPartnershipResult = self.searchPartnershipUseCase.newSearchExecute()
                     
-                    promise(.success(partnershipResult + newPartnershipResult))
+                    let results = try await (partnershipResult + newPartnershipResult)
+                    promise(.success(results))
                 } catch {
                     promise(.failure(.serverFailed))
                 }

--- a/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
@@ -263,11 +263,10 @@ private extension HomeViewModel {
             
             Task {
                 do {
-                    async let partnershipResult = self.searchPartnershipUseCase.searchExecute()
-                    async let newPartnershipResult = self.searchPartnershipUseCase.newSearchExecute()
+                    let partnershipResult = try await self.searchPartnershipUseCase.searchExecute()
+                    let newPartnershipResult = try await self.searchPartnershipUseCase.newSearchExecute()
                     
-                    let results = try await (partnershipResult + newPartnershipResult)
-                    promise(.success(results))
+                    promise(.success(partnershipResult + newPartnershipResult))
                 } catch {
                     promise(.failure(.serverFailed))
                 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #47 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- `transform` 내부의 데이터 요청 로직을 `fetchStoreItems`, `fetchPartnershipItems` 메서드로 분리하여 가독성 개선
- API 호출 부분을 `postNearStorePublisher`, `postPartnershipPublisher` 등 저수준 함수로 분리하여 역할 명확화
- ~`async let` 을 사용해 일반/신규 제휴사 정보를 병렬로 조회하도록 개선하여 홈 화면 로딩 속도 단축~ -> 병렬 조회 제거, 기존 코드 유지

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### ♻️ HomeViewModel 로직 개선

`HomeViewModel` 의 코드 품질, 가독성 및 유지보수성을 향상시키기 위해 전체적인 리팩토링을 진행했습니다. 
복잡한 Combine 스트림 로직을 단순화하고, 중복 코드를 제거했으며, 프로젝트의 코드 스타일에 맞춰 문서 주석을 보강했습니다.

**1. `transform(input:) `메서드 로직 분리 및 단순화**
- 기존 flatMap 내부에 있던 복잡한 switch 문과 중복 코드를 `fetchStoreItems`(), `fetchPartnershipItems()` 라는 두 개의 명확한 역할을 가진 private 메서드로 분리했습니다.
- 결과적으로 `transform` 메서드는 데이터 흐름을 조합하는 역할에만 집중하게 되어 가독성이 크게 향상되었습니다.

<br>

~**2. `async let` 을 이용한 API 호출 병렬 처리**~
~- `postPartnershipPublisher` 메서드에서 두 개의 `searchPartnershipUseCase` 호출을 `async let` 으로 동시에 실행하도록 수정했습니다.~
~- 불필요한 순차 실행을 제거하여 제휴사 정보를 더 빠르게 가져올 수 있도록 성능을 개선했습니다.~

> 병렬 처리를 한후 다시 테스트를 해보았는데 성능상 이점이 없는 결과를 얻어 다시 기존 코드를 유지하였습니다. 
해당 결과는 추후 정리하여 게시하겠습니다.

<br>

**3. `postPartnershipPublisher` 반환 타입 명확화**
- `postPartnershipPublisher()` 메서드에서 불필요하게 옵셔널 배열(`[PartnershipModel]?`)을 반환하던 문제를 수정했습니다.
- 이제 성공 시 항상 non-optional 배열(`[PartnershipModel]`)을 반환하여 타입 안정성을 높이고 사용하는 `fetchPartnershipItems()` 에서 불필요한 옵셔널 처리 코드를 제거했습니다.

<br>

**4. DocC 문서 주석 추가 및 통일**
- 프로젝트의 기존 스타일 가이드에 맞춰 새로 추가된 모든 private 메서드에 DocC 형식의 상세한 주석을 추가했습니다.
- 각 메서드의 역할, 파라미터, 반환 값을 명확히 하여 코드 이해도를 높이고 유지보수를 용이하게 만들었습니다.

<br>

**5. Private Extension 구조 정리**
- 여러 개로 흩어져 있던 private extension들을 하나의 **// MARK: - Private Extension** 으로 통합하고 내부적으로 로직의 계층(High-Level/Low-Level)에 따라 그룹화하여 코드 구조를 명확하게 개선했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
