### PR TITLE
[Refactor] #49 - NMapsMap 과 Kakao SDK 라이브러리를 정적 라이브러리로 변경

### DIFF
--- a/Terbuck/Tuist/Package.resolved
+++ b/Terbuck/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2ef0666d89daa7ae4e4b240fcb8b6212f29017a60f31c58f2c63ee2ef67daff3",
+  "originHash" : "bf8498c554a7f4ec163cdf6fa5bc0d85e44c18cda8c859f65bc9cc947635298b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
-        "version" : "1.29.0"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     },
     {

--- a/Terbuck/Tuist/Package.swift
+++ b/Terbuck/Tuist/Package.swift
@@ -7,13 +7,6 @@ import PackageDescription
     let packageSettings = PackageSettings(
         // Customize the product types for specific package product
         // Default is .staticFramework
-        // productTypes: ["Alamofire": .framework,]
-        productTypes: [
-            "KakaoSDKCommon": .framework,
-            "KakaoSDKAuth": .framework,
-            "KakaoSDKUser": .framework,
-            "NMapsMap": .framework,
-        ]
     )
 #endif
 


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #49 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- NMapsMap 과 Kakao SDK 라이브러리를 정적으로 변경

<br>


## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

[**🚀 Firebase SDK SPM vs XCFramework 따른 iOS 앱 Launch Time 비교**](https://github.com/Studing-Team/Terbuck-iOS/wiki/%F0%9F%9A%80-Firebase-SDK-SPM-vs-XCFramework-%EB%94%B0%EB%A5%B8-iOS-%EC%95%B1-Launch-Time-%EB%B9%84%EA%B5%90) 를 참고해주시면 감사하겠습니다.

요약하자면 다음과 같은 의존성 설정으로 인해서 LaunchTime 이 약 18% 개선이 되었습니다.

<br>

## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
