### PR TITLE
[Hotfix] #56 - 제휴업체 지도 & 모달 관련 에러 문제 해결

### DIFF
--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreListModalViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreListModalViewController.swift
@@ -391,9 +391,6 @@ extension StoreListModalViewController: UICollectionViewDelegate {
         if scrollView == storeCollectionView {
             if scrollView.contentOffset.y < 0 {
                 scrollView.contentOffset.y = 0
-                storeCollectionView.isScrollEnabled = false
-            } else {
-                storeCollectionView.isScrollEnabled = true
             }
         }
     }
@@ -425,8 +422,12 @@ extension StoreListModalViewController: UIGestureRecognizerDelegate {
         let isCollectionViewAtTop = self.storeCollectionView.contentOffset.y <= 0
         
         // 사용자가 위로 스크롤(모달 확장)하려는 경우는 항상 허용
-        if velocity.y < 0 {
+        if velocity.y < 0 && currentSnapIndex != 3 {
+            storeCollectionView.isScrollEnabled = false
             return true
+        } else if velocity.y < 0 && currentSnapIndex == 3 {
+            storeCollectionView.isScrollEnabled = true
+            return false
         }
         
         // 사용자가 아래로 스크롤하고, 컬렉션뷰가 최상단에 있을 때만 허용

--- a/Terbuck/Feature/StoreFeature/Sources/ViewModel/StoreMapViewModel.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewModel/StoreMapViewModel.swift
@@ -65,7 +65,7 @@ public final class StoreMapViewModel {
     
     // MARK: - Output Combine Publishers Properties
     
-    public let initStoreDataSubject = PassthroughSubject<[StoreListModel], Never>()
+    public let initStoreDataSubject = CurrentValueSubject<[StoreListModel], Never>([])
     public let storeListSubject = CurrentValueSubject<[StoreListModel], Never>([])
     public let categoryItemsSubject = CurrentValueSubject<[CategoryModel], Never>([])
     public let storeItemsTappedResult = PassthroughSubject<Int, Never>()
@@ -147,8 +147,19 @@ public final class StoreMapViewModel {
        
         didSelectItemSubject
             .sink { [weak self] index in
-                guard let data = self?.storeListSubject.value[index] else { return }
-                self?.storeItemsTappedResult.send(data.id)
+                guard let self else { return }
+                let categoryIndex = self.storeCategoryPublisher.value
+                
+                // 전체 카테고리
+                if categoryIndex == 0 {
+                    let data = self.initStoreDataSubject.value[index]
+                    self.storeItemsTappedResult.send(data.id)
+                } else {
+                    let category = self.categoryItemsSubject.value[categoryIndex]
+                    guard let datas = self.categoryStoreData[category.type] else { return }
+
+                    self.storeItemsTappedResult.send(datas[index].id)
+                }
             }
             .store(in: &cancellables)
         

--- a/Terbuck/Project.swift
+++ b/Terbuck/Project.swift
@@ -4,8 +4,8 @@ import ProjectDescription
 
 let projectSettings: Settings = .settings(
     base: [
-        "MARKETING_VERSION": "1.0.1",
-        "CURRENT_PROJECT_VERSION": "4",
+        "MARKETING_VERSION": "1.0.2",
+        "CURRENT_PROJECT_VERSION": "1",
         "DEVELOPMENT_TEAM": "N3H27N59VG",
         "CODE_SIGN_STYLE": "Automatic",
         "OTHER_LDFLAGS": ["-all_load"],


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #56 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 제휴업체 지도 하단 모달의 셀 선택 시 인덱스 오류 수정
- 제휴업체 지도 하단 모달의 제스처 동작 개선

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

###  1. 제휴업체 지도 하단 모달의 셀 선택 시 인덱스 오류 수정
- 제휴업체 지도에서 데이터를 불러오는 로직을 수정하고 나서 해당 셀을 눌렀을때 값을 갖고 있는 변수로 바꾸지 않아 Index 오류가 났습니다.
- 기존의 변수가 아닌 수정된 로직에서 값을 갖고 있는 변수로 로직을 수정하여 Index 오류를 수정했습니다.

### 2. 제휴업체 지도 하단 모달의 제스처 동작 개선

- 모달이 최상단 위치에 있을 때 사용자가 아래로 스와이프하는 제스처가 정상적으로 동작하지 않는 문제가 있었습니다.
- 기존 구현은 `CollectionView` 의 `contentOffset.y` 가 0 이하일 경우 제스처 인식을 제한하여 발생한 문제입니다.
- 이 부분을 제거하고 `gestureRecognizerShouldBegin` 메서드에서 적절한 조건을 판단하여 제스처 인식을 제어하도록 개선하였습니다.
- 결과적으로 모달 제스처가 보다 자연스럽고 의도한 대로 동작하게 되었습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
