### PR TITLE
[Fix] #61 - 버튼 중복 탭 방지를 위한 throttle 로직 추가

### DIFF
--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
@@ -94,6 +94,7 @@ public final class RegisterStudentCardViewModel {
             .store(in: &cancellables)
         
         let registerBottomButtonResult = input.bottomButtonTapped
+            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: false)
             .handleEvents(receiveOutput:  { _ in
                 MixpanelManager.shared.track(eventType: TrackEventType.Home.registerButtonTappedInRegisterView)
             })

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/MajorInfoViewModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/MajorInfoViewModel.swift
@@ -61,6 +61,7 @@ public class MajorInfoViewModel: ObservableObject {
             .eraseToAnyPublisher()
         
         let bottomButtonResult = input.bottomButtonTapped
+            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: false)
             .flatMap { [weak self] _ -> AnyPublisher<Bool, Never> in
                 guard let self else {
                     return Just(false).eraseToAnyPublisher()


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #61

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
-  학생증 등록 화면(RegisterStudentCardViewModel)의 버튼 이벤트에 throttle 연산자를 적용
-  대학교 등록 화면(MajorInfoViewModel)의 버튼 이벤트에 throttle 연산자를 적용

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 버튼 중복 탭 방지를 위한 throttle 로직 추가

**문제 상황**
- 기존에는 학생증 등록 버튼을 누를 때마다 API 호출이 즉시 트리거되었습니다.
- 네트워크 지연 등의 이유로 사용자가 버튼을 여러 번 누를 경우, API가 중복으로 호출되어 서버에 불필요한 부하를 주고 데이터 정합성에 문제를 일으킬 수 있는 잠재적 위험이 있었습니다.

**해결 방안**
- `bottomButtonTapped` 이벤트 스트림에 Combine 의 `throttle` 연산자를 추가했습니다.
- `throttle(for: .seconds(1), scheduler: RunLoop.main, latest: false)` 설정을 통해 첫 번째 탭은 즉시 처리하여 API를 호출하고 이후 1초 동안의 추가적인 탭은 모두 무시하도록 구현했습니다.
- 사용자 경험을 해치지 않으면서도 시스템 안정성을 높였습니다.

<br>

**[참고] debounce vs throttle 상세 비교**

이번 수정을 진행하며 함께 고려했던 debounce와의 차이점을 공유하기 위해 정리합니다.


|구분|debounce|throttle (latest: false)|
|:--:|:--:|:--:|
|동작|이벤트가 멈춘 후 마지막 신호만 처리|첫 신호를 즉시 처리 후 일정 시간 무시|
|실행 타이밍|지연 실행 (Delayed)|즉시 실행 (Immediate)|
|목적|그룹화된 이벤트의 최종 결과 얻기|이벤트의 발생 빈도 제어하기 |
|예시|검색창 자동 완성|버튼 중복 클릭 방지|

이번 버튼 중복 클릭 방지 케이스에서는 "즉시 실행"이 사용자 경험에 더 적합하므로 `throttle` 을 선택했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
