### PR TITLE
[Feat] #66 - 지역별 대학교 데이터 조회 API 구현

### DIFF
--- a/Terbuck/Core/CoreNetwork/Sources/University/DTO/Response/UniversityInfoListResponseDTO.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/University/DTO/Response/UniversityInfoListResponseDTO.swift
@@ -1,0 +1,42 @@
+//
+//  UniversityInfoListResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 9/4/25.
+//
+
+import Foundation
+
+public struct UniversityInfoListResponseDTO: Codable {
+    public let region: RegionInfoData
+    public let universities: [UniversityInfoData]
+    
+    public init(region: RegionInfoData, universities: [UniversityInfoData]) {
+        self.region = region
+        self.universities = universities
+    }
+}
+
+public struct RegionInfoData: Codable {
+    public let id: Int
+    public let name: String
+    
+    public init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+public struct UniversityInfoData: Codable {
+    public let id: Int
+    public let name: String
+    public let region: RegionInfoData
+    public let registered: Bool
+    
+    public init(id: Int, name: String, region: RegionInfoData, registered: Bool) {
+        self.id = id
+        self.name = name
+        self.region = region
+        self.registered = registered
+    }
+}

--- a/Terbuck/Core/CoreNetwork/Sources/University/UniversityAPIEndpoint.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/University/UniversityAPIEndpoint.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public enum UniversityAPIEndpoint {
+    case getUniversityInfoList
     /// 우리 학교의 제휴 업체 '공개 상태'를 조회
     case getPartnershipDisclosureStatus(MyUniversityRequestDTO)
     /// 제휴 업체 '공개 요청'을 생성
@@ -23,6 +24,8 @@ extension UniversityAPIEndpoint: EndpointProtocol {
     
     public var path: String {
         switch self {
+        case .getUniversityInfoList:
+            return basePath.rawValue + "/by-region"
         case .getPartnershipDisclosureStatus:
             return basePath.rawValue + "/is-registered"
         case .postPartnershipDisclosureRequest, .getDisclosureRequestStatus:
@@ -32,7 +35,7 @@ extension UniversityAPIEndpoint: EndpointProtocol {
     
     public var method: HTTPMethod {
         switch self {
-        case .getPartnershipDisclosureStatus, .getDisclosureRequestStatus:
+        case .getUniversityInfoList, .getPartnershipDisclosureStatus, .getDisclosureRequestStatus:
             return .get
         case .postPartnershipDisclosureRequest:
             return .post
@@ -55,6 +58,8 @@ extension UniversityAPIEndpoint: EndpointProtocol {
             return dto.toQueryItems()
         case .postPartnershipDisclosureRequest(let dto):
             return dto.toQueryItems()
+        default:
+            return nil
         }
     }
     

--- a/Terbuck/Feature/AuthFeature/Sources/View/TermsListView.swift
+++ b/Terbuck/Feature/AuthFeature/Sources/View/TermsListView.swift
@@ -24,18 +24,14 @@ public final class TermsListView: UIView {
     public enum TermsType {
         case service
         case userInfo
-        case marketing
         
         var title: String {
             switch self {
             case .service:
-                return "[필수]  서비스 이용약관"
+                return "[필수] 서비스 이용약관"
                 
             case .userInfo:
-                return "[필수]  개인정보 수집 및 이용동의"
-                
-            case .marketing:
-                return "[선택]  개인정보 수집 및 이용동의"
+                return "[필수] 개인정보 수집 및 이용동의"
             }
         }
     }

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/Data/RegisterRepositoryImpl.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/Data/RegisterRepositoryImpl.swift
@@ -1,5 +1,5 @@
 //
-//  RegisterRepository.swift
+//  RegisterRepositoryImpl.swift
 //  CoreNetwork
 //
 //  Created by ParkJunHyuk on 6/4/25.

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Data/Entity/UniversityInfoEntity.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Data/Entity/UniversityInfoEntity.swift
@@ -10,8 +10,8 @@ import CoreNetwork
 
 public struct UniversityInfoEntity {
     let id: Int
-    let regions: String
-    let university: [String]
+    let regionName: String
+    let universityNames: [String]
 }
 
 extension UniversityInfoListResponseDTO {
@@ -23,8 +23,8 @@ extension UniversityInfoListResponseDTO {
         
         return UniversityInfoEntity(
             id: region.id,
-            regions: region.name,
-            university: convertUniversityName
+            regionName: region.name,
+            universityNames: convertUniversityName
         )
     }
 }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Data/Entity/UniversityInfoEntity.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Data/Entity/UniversityInfoEntity.swift
@@ -1,0 +1,30 @@
+//
+//  UniversityInfoEntity.swift
+//  UniversityInfoFeature
+//
+//  Created by ParkJunHyuk on 9/4/25.
+//
+
+import Foundation
+import CoreNetwork
+
+public struct UniversityInfoEntity {
+    let id: Int
+    let regions: String
+    let university: [String]
+}
+
+extension UniversityInfoListResponseDTO {
+    func toEntity() -> UniversityInfoEntity {
+
+        let convertUniversityName = self.universities.map {
+            $0.name
+        }
+        
+        return UniversityInfoEntity(
+            id: region.id,
+            regions: region.name,
+            university: convertUniversityName
+        )
+    }
+}

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Data/UniversityRepositoryImpl.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Data/UniversityRepositoryImpl.swift
@@ -1,5 +1,5 @@
 //
-//  UniversityRepository.swift
+//  UniversityRepositoryImpl.swift
 //  CoreNetwork
 //
 //  Created by ParkJunHyuk on 6/11/25.
@@ -11,6 +11,7 @@ import CoreNetwork
 public protocol UniversityRepository {
     func postSignupMember(university: String) async throws -> Void
     func patchUniversityInfo(university: String) async throws -> Void
+    func getUniversityInfoList() async throws -> [UniversityInfoEntity]
 }
 
 public struct UniversityRepositoryImpl: UniversityRepository {
@@ -28,5 +29,11 @@ public struct UniversityRepositoryImpl: UniversityRepository {
         let requestDTO = ChangeUniversityRequestDTO(university: university)
         
         let _: EmptyResponseDTO = try await networkManager.request(MemberAPIEndpoint.patchUniversity(requestDTO))
+    }
+    
+    public func getUniversityInfoList() async throws -> [UniversityInfoEntity] {
+        let dto: [UniversityInfoListResponseDTO] = try await networkManager.request(UniversityAPIEndpoint.getUniversityInfoList)
+        
+        return dto.map { $0.toEntity() }
     }
 }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Domain/FetchUniversityInfoListUseCase.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Domain/FetchUniversityInfoListUseCase.swift
@@ -27,17 +27,12 @@ public struct FetchUniversityInfoListUseCaseImpl: FetchUniversityInfoListUseCase
 
 extension FetchUniversityInfoListUseCaseImpl {
     func convertToModel(_ entity: [UniversityInfoEntity]) -> [UniversityInfoModel] {
-        
-        var convertModel = [UniversityInfoModel]()
-        
-        entity.forEach {
-            convertModel.append(UniversityInfoModel(
+        return entity.map {
+            UniversityInfoModel(
                 id: $0.id,
-                title: $0.regions,
-                items: $0.university)
+                title: $0.regionName,
+                items: $0.universityNames
             )
         }
-        
-        return convertModel
     }
 }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Domain/FetchUniversityInfoListUseCase.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Domain/FetchUniversityInfoListUseCase.swift
@@ -1,0 +1,43 @@
+//
+//  FetchUniversityInfoListUseCase.swift
+//  RegisterStudentCardFeature
+//
+//  Created by ParkJunHyuk on 9/4/25.
+//
+
+import Foundation
+
+public protocol FetchUniversityInfoListUseCase {
+    func execute() async throws -> [UniversityInfoModel]
+}
+
+public struct FetchUniversityInfoListUseCaseImpl: FetchUniversityInfoListUseCase {
+    let repository: UniversityRepository
+    
+    public init(repository: UniversityRepository) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> [UniversityInfoModel] {
+        let entity = try await repository.getUniversityInfoList()
+        
+        return convertToModel(entity)
+    }
+}
+
+extension FetchUniversityInfoListUseCaseImpl {
+    func convertToModel(_ entity: [UniversityInfoEntity]) -> [UniversityInfoModel] {
+        
+        var convertModel = [UniversityInfoModel]()
+        
+        entity.forEach {
+            convertModel.append(UniversityInfoModel(
+                id: $0.id,
+                title: $0.regions,
+                items: $0.university)
+            )
+        }
+        
+        return convertModel
+    }
+}

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Factory/MajorInfoFactoryImpl.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Factory/MajorInfoFactoryImpl.swift
@@ -22,10 +22,16 @@ public final class MajorInfoFactoryImpl: MajorInfoFactory {
         
         switch type {
         case .edit:
-            viewModel = MajorInfoViewModel(selectedUniversityName: universityName)
+            viewModel = MajorInfoViewModel(
+                selectedUniversityName: universityName,
+                editUniversityUseCase: EditUniversityUseCaseImpl(repository: UniversityRepositoryImpl())
+            )
             
         case .register:
-            viewModel = MajorInfoViewModel(selectedUniversityName: universityName)
+            viewModel = MajorInfoViewModel(
+                selectedUniversityName: universityName,
+                signupUseCase: SignupUseCaseImpl(repository: UniversityRepositoryImpl())
+            )
         }
         
         return MajorInfoViewController(

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Factory/UniversityInfoFactoryImpl.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Factory/UniversityInfoFactoryImpl.swift
@@ -17,19 +17,10 @@ public final class UniversityInfoFactoryImpl: UniversityInfoFactory {
         coordinator: UniversityInfoCoordinating
     ) -> UIViewController {
         
-        let viewModel: UniversityViewModel
-        
-        switch type {
-        case .edit:
-            viewModel = UniversityViewModel(
-                editUniversityUseCase: EditUniversityUseCaseImpl(repository: UniversityRepositoryImpl())
-            )
-        case .register:
-            viewModel = UniversityViewModel(
-                signupUseCase: SignupUseCaseImpl(repository: UniversityRepositoryImpl())
-            )
-        }
-        
+        let viewModel = UniversityViewModel(
+            fetchUniversityInfoListUseCase: FetchUniversityInfoListUseCaseImpl(repository: UniversityRepositoryImpl())
+        )
+
         return UniversityViewController(
             type: type,
             viewModel: viewModel,

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Model/UniversityInfoModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Model/UniversityInfoModel.swift
@@ -1,0 +1,14 @@
+//
+//  UniversityInfoModel.swift
+//  UniversityInfoFeature
+//
+//  Created by ParkJunHyuk on 9/4/25.
+//
+
+import Foundation
+
+public struct UniversityInfoModel: Identifiable {
+    public var id: Int
+    public let title: String
+    public let items: [String]
+}

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
@@ -28,7 +28,6 @@ struct InfomationSectionView: View {
             return nil
         }
         
-        print("선택되어있는 모델", model[selectedSectionIndex])
         return model[selectedSectionIndex]
     }
     

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
@@ -15,116 +15,118 @@ enum SectionType {
 
 struct InfomationSectionView: View {
     
-    @ObservedObject var viewModel: UniversityViewModel
+    @State var viewModel: UniversityViewModel
     @State private var isExpanded: Bool = true
     @State private var sectionType: SectionType = .university
     @State private var selectedSectionIndex: Int = 0
     
-    var selectedSection: UniversityInfoModel {
-        sections[selectedSectionIndex]
+    // MARK: - Properties
+    
+    var selectedSection: UniversityInfoModel? {
+        guard let model = viewModel.universityInfoModel,
+              model.indices.contains(selectedSectionIndex) else {
+            return nil
+        }
+        
+        print("선택되어있는 모델", model[selectedSectionIndex])
+        return model[selectedSectionIndex]
     }
     
-    let sections = [
-        UniversityInfoModel(
-            title: "강남 · 서초 · 송파 · 강동",
-            items: ["KCD대학교", "서울교육대학교", "총신대학교(서초캠퍼스)", "한국체육대학교", "한영신학대학교" , "홍익대학교", "연세대학교", "이화여자대학교", "서강대학교", "추계예술대학교"]
-        ),
-        UniversityInfoModel(
-            title: "마포 · 서대문 · 은평",
-            items: ["홍익대학교", "연세대학교", "이화여자대학교", "서강대학교", "추계예술대학교", "KCD대학교", "서울교육대학교", "총신대학교(서초캠퍼스)", "한국체육대학교", "한영신학대학교" ]
-        ),
-        UniversityInfoModel(
-            title: "종로 · 중구 · 성동",
-            items: ["서울대학교", "한양대학교", "성균관대학교", "동국대학교", "중앙대학교", "홍익대학교", "연세대학교", "이화여자대학교", "서강대학교", "추계예술대학교"]
-        )
-    ]
-    
+    // MARK: - Body
     
     var body: some View {
-        VStack(spacing: 18) {
-            Button(action: {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    // 먼저 접기
-                    isExpanded = false
-                    
-                    // 잠시 후 타입 변경하고 다시 펼치기
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                        sectionType = sectionType == .university ? .location : .university
-                        viewModel.selectItem(nil)
+        Group {
+            if let universityInfo = viewModel.universityInfoModel, let currentSection = selectedSection {
+                VStack(spacing: 18) {
+                    Button(action: {
                         withAnimation(.easeInOut(duration: 0.3)) {
-                            isExpanded = true
-                        }
-                    }
-                }
-            }) {
-                HStack(spacing: 0) {
-                    Text(selectedSection.title)
-                        .font(DesignSystem.Font.swiftUIFont(.textSemi16))
-                        .foregroundStyle(DesignSystem.Color.swiftUIColor(.terbuckBlack50))
-                    
-                    Spacer()
-                    
-                    Image(systemName: "chevron.down")
-                        .foregroundColor(DesignSystem.Color.swiftUIColor(.terbuckBlack10))
-                        .rotationEffect(.degrees(isExpanded ? 180 : 0))
-                }
-                .padding(.vertical, 16.5)
-                .padding(.horizontal, 20)
-                .background(DesignSystem.Color.swiftUIColor(.terbuckWhite5))
-                .cornerRadius(8)
-            }
-            
-            // 아코디언 내용
-            VStack(spacing: 0) {
-                if sectionType == .university {
-                    UniversitySectionView(
-                        section: selectedSection.items,
-                        selectedItem: viewModel.selectedItemForUI,
-                        onItemSelected: { item in
-                            viewModel.selectItem(item)
-                        }
-                    )
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                } else if sectionType == .location {
-                    LocationSectionView(
-                        section: sections.map { $0.title },
-                        onItemSelected: { item in
-                            if let index = sections.firstIndex(where: { $0.title == item }) {
+                            isExpanded = false
+                            
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                                sectionType = sectionType == .university ? .location : .university
+                                
+                                viewModel.selectItem(nil)
                                 withAnimation(.easeInOut(duration: 0.3)) {
-                                    isExpanded = false
-                                    selectedSectionIndex = index
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                                        sectionType = .university
-                                        
-                                        withAnimation(.easeInOut(duration: 0.3)) {
-                                            isExpanded = true
-                                        }
+                                    isExpanded = true
+                                }
+                            }
+                        }
+                    }) {
+                        HStack(spacing: 0) {
+                            Text(currentSection.title)
+                                .font(DesignSystem.Font.swiftUIFont(.textSemi16))
+                                .foregroundStyle(DesignSystem.Color.swiftUIColor(.terbuckBlack50))
+                            
+                            Spacer()
+                            
+                            Image(systemName: "chevron.down")
+                                .foregroundColor(DesignSystem.Color.swiftUIColor(.terbuckBlack10))
+                                .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                        }
+                        .padding(.vertical, 16.5)
+                        .padding(.horizontal, 20)
+                        .background(DesignSystem.Color.swiftUIColor(.terbuckWhite5))
+                        .cornerRadius(8)
+                    }
+                
+                    accordionSectionView(universityInfo: universityInfo, currentSection: currentSection)
+                }
+                .padding(.horizontal, 20)
+                .onAppear {
+                    sectionType = .university
+                    isExpanded = true
+                }
+                .transition(.opacity)
+            } else {
+                VStack(spacing: 0) {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.4), value: viewModel.universityInfoModel != nil)
+    }
+    
+    func accordionSectionView(universityInfo: [UniversityInfoModel], currentSection: UniversityInfoModel) -> some View {
+        VStack(spacing: 0) {
+            if sectionType == .university {
+                UniversitySectionView(
+                    section: currentSection.items,
+                    selectedItem: viewModel.selectedItemForUI,
+                    onItemSelected: { item in
+                        viewModel.selectItem(item)
+                    }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            } else if sectionType == .location {
+                LocationSectionView(
+                    section: universityInfo.map { $0.title },
+                    onItemSelected: { item in
+                        if let index = universityInfo.firstIndex(where: { $0.title == item }) {
+                            withAnimation(.easeInOut(duration: 0.3)) {
+                                isExpanded = false
+                                selectedSectionIndex = index
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                                    sectionType = .university
+                                    
+                                    withAnimation(.easeInOut(duration: 0.3)) {
+                                        isExpanded = true
                                     }
                                 }
                             }
                         }
-                    )
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                }
+                    }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
             }
-            .scaleEffect(y: isExpanded ? 1 : 0, anchor: .top)
-            .clipped()
         }
-        .padding(.horizontal, 20)
-        .onAppear {
-            // 초기 상태: university 모드에서 펼쳐진 상태
-            sectionType = .university
-            isExpanded = true
-        }
+        .scaleEffect(y: isExpanded ? 1 : 0, anchor: .top)
     }
 }
 
 //#Preview {
 //    InfomationSectionView()
 //}
-
-
-struct UniversityInfoModel {
-    let title: String
-    let items: [String]
-}

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/View/UniversitySectionView.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/View/UniversitySectionView.swift
@@ -18,7 +18,7 @@ struct UniversitySectionView: View {
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 8) {
-                ForEach(Array(section.enumerated()), id: \.offset) { index, item in
+                ForEach(section, id: \.self) { item in
                     HStack(spacing: 0) {
                         Text(item)
                             .font(DesignSystem.Font.swiftUIFont(.textRegular14))

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/UniversityViewController.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/UniversityViewController.swift
@@ -24,6 +24,10 @@ public final class UniversityViewController: UIViewController, UIGestureRecogniz
     private var viewModel: UniversityViewModel
     public weak var delegate: RegisterUniversityDelegate?
     weak var coordinator: UniversityInfoCoordinating?
+    
+    // MARK: - Combine Properties
+    
+    private let viewLifeCycleSubject = PassthroughSubject<ViewLifeCycleEvent, Never>()
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - UI Properties
@@ -68,6 +72,8 @@ public final class UniversityViewController: UIViewController, UIGestureRecogniz
         setupLayout()
         setupDelegate()
         bindViewModel()
+        
+        viewLifeCycleSubject.send(.viewDidLoad)
     }
 }
 
@@ -76,6 +82,7 @@ public final class UniversityViewController: UIViewController, UIGestureRecogniz
 private extension UniversityViewController {
     func bindViewModel() {
         let input = UniversityViewModel.Input(
+            viewLifeCycleEventAction: viewLifeCycleSubject.eraseToAnyPublisher(),
             bottomButtonTapped: terbuckBottomButton.tapPublisher
         )
         
@@ -131,10 +138,10 @@ private extension UniversityViewController {
         hostingController.view.snp.makeConstraints {
             $0.top.equalTo(titleView.snp.bottom).offset(view.convertByHeightRatio(120))
             $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(view.convertByHeightRatio(360))
         }
         
         terbuckBottomButton.snp.makeConstraints {
-            $0.top.equalTo(hostingController.view.snp.bottom).offset(view.convertByHeightRatio(20))
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(view.convertByHeightRatio(8))
         }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/MajorInfoViewModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/MajorInfoViewModel.swift
@@ -14,7 +14,8 @@ public class MajorInfoViewModel: ObservableObject {
     
     // MARK: - Properties
     
-    
+    private var signupUseCase: SignupUseCase?
+    private var editUniversityUseCase: EditUniversityUseCase?
     
     // MARK: - Private Combine Publishers Properties
     
@@ -45,9 +46,13 @@ public class MajorInfoViewModel: ObservableObject {
     // MARK: - Init
     
     public init(
-        selectedUniversityName: String
+        selectedUniversityName: String,
+        signupUseCase: SignupUseCase? = nil,
+        editUniversityUseCase: EditUniversityUseCase? = nil,
     ) {
         self.selectedUniversityNameSubject.send(selectedUniversityName)
+        self.signupUseCase = signupUseCase
+        self.editUniversityUseCase = editUniversityUseCase
     }
     
     // MARK: - Public methods
@@ -95,5 +100,46 @@ public extension MajorInfoViewModel {
 // MARK: - Private API methods
 
 private extension MajorInfoViewModel {
+    func signupPublisher(_ university: String) -> AnyPublisher<Void, UniversityError> {
+        return Future { [weak self] promise in
+            guard let self, let signupUseCase else {
+                promise(.failure(.unknown))
+                return
+            }
+            
+            Task {
+                do {
+                    _ = try await signupUseCase.execute(university: university)
+                    promise(.success(()))
+                } catch {
+                    promise(.failure(.signupFailed))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
     
+    func editUniversityPublisher(_ university: String) -> AnyPublisher<Void, UniversityError> {
+        return Future { [weak self] promise in
+            guard let self, let editUniversityUseCase else {
+                promise(.failure(.unknown))
+                return
+            }
+            
+            if university == UserDefaultsManager.shared.string(for: .university) {
+                promise(.failure(.notEditUniversity))
+                return
+            }
+            
+            Task {
+                do {
+                    let _ = try await editUniversityUseCase.execute(university: university)
+                    promise(.success(()))
+                } catch {
+                    promise(.failure(.editUniversityFailed))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
 }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/UniversityViewModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/UniversityViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import Observation
 
 import Shared
 
@@ -30,14 +31,12 @@ enum UniversityError: LocalizedError, Equatable {
     }
 }
 
-public class UniversityViewModel: ObservableObject {
+@Observable
+public class UniversityViewModel {
     
     // MARK: - Properties
     
-    private var signupUseCase: SignupUseCase?
-    private var editUniversityUseCase: EditUniversityUseCase?
-    
-    var universityName: String? = nil
+    private var fetchUniversityInfoListUseCase: FetchUniversityInfoListUseCase
     
     // MARK: - Private Combine Publishers Properties
     
@@ -48,12 +47,13 @@ public class UniversityViewModel: ObservableObject {
     
     // MARK: - SwiftUI Published Properties
     
-    @Published var selectedItemForUI: String?
+    var selectedItemForUI: String?
+    var universityInfoModel: [UniversityInfoModel]?
     
     // MARK: - Input
     
     struct Input {
-//        let universityTapped: AnyPublisher<String?, Never>
+        let viewLifeCycleEventAction: AnyPublisher<ViewLifeCycleEvent, Never>
         let bottomButtonTapped: AnyPublisher<Void, Never>
     }
     
@@ -68,16 +68,34 @@ public class UniversityViewModel: ObservableObject {
     // MARK: - Init
     
     public init(
-        signupUseCase: SignupUseCase? = nil,
-        editUniversityUseCase: EditUniversityUseCase? = nil
+        fetchUniversityInfoListUseCase: FetchUniversityInfoListUseCase
     ) {
-        self.signupUseCase = signupUseCase
-        self.editUniversityUseCase = editUniversityUseCase
+        self.fetchUniversityInfoListUseCase = fetchUniversityInfoListUseCase
     }
     
     // MARK: - Public methods
     
     func transform(input: Input) -> Output {
+        input.viewLifeCycleEventAction
+            .filter { $0 == .viewDidLoad }
+            .flatMap { [weak self] _ -> AnyPublisher<[UniversityInfoModel], Never> in
+                guard let self else { return Just([]).eraseToAnyPublisher() }
+                
+                return self.fetchUniversityPublisher()
+                    .catch { [weak self] error -> Just<[UniversityInfoModel]> in
+                        self?.errorSubject.send(error)
+                        return Just([])
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .delay(for: .seconds(0.5), scheduler: DispatchQueue.main)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] universityInfo in
+                self?.universityInfoModel = universityInfo
+            }
+            .store(in: &cancellables)
+        
+        
         let isBottomButtonEnabled = selectedUniversitySubject
             .map { selectedItem in
                 selectedItem == nil ? false : true
@@ -115,41 +133,17 @@ public extension UniversityViewModel {
 // MARK: - Private API methods
 
 private extension UniversityViewModel {
-    func signupPublisher(_ university: String) -> AnyPublisher<Void, UniversityError> {
+    func fetchUniversityPublisher() -> AnyPublisher<[UniversityInfoModel], UniversityError> {
         return Future { [weak self] promise in
-            guard let self, let signupUseCase else {
+            guard let self else {
                 promise(.failure(.unknown))
                 return
             }
             
             Task {
                 do {
-                    _ = try await signupUseCase.execute(university: university)
-                    promise(.success(()))
-                } catch {
-                    promise(.failure(.signupFailed))
-                }
-            }
-        }
-        .eraseToAnyPublisher()
-    }
-    
-    func editUniversityPublisher(_ university: String) -> AnyPublisher<Void, UniversityError> {
-        return Future { [weak self] promise in
-            guard let self, let editUniversityUseCase else {
-                promise(.failure(.unknown))
-                return
-            }
-            
-            if university == UserDefaultsManager.shared.string(for: .university) {
-                promise(.failure(.notEditUniversity))
-                return
-            }
-            
-            Task {
-                do {
-                    let _ = try await editUniversityUseCase.execute(university: university)
-                    promise(.success(()))
+                    let result = try await self.fetchUniversityInfoListUseCase.execute()
+                    promise(.success(result))
                 } catch {
                     promise(.failure(.editUniversityFailed))
                 }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/UniversityViewModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/UniversityViewModel.swift
@@ -12,19 +12,13 @@ import Observation
 import Shared
 
 enum UniversityError: LocalizedError, Equatable {
-    case signupFailed
-    case editUniversityFailed
-    case notEditUniversity
+    case fetchFailed
     case unknown
-
+    
     var errorDescription: String? {
         switch self {
-        case .signupFailed:
-            return "회원가입에 실패했습니다."
-        case .editUniversityFailed:
-            return "대학교를 변경하지 못했습니다."
-        case .notEditUniversity:
-            return "대학교를 변경할 수 없습니다"
+        case .fetchFailed:
+            return "대학교 정보를 불러올 수 없습니다."
         case .unknown:
             return "알 수 없는 오류가 발생했어요."
         }
@@ -145,7 +139,7 @@ private extension UniversityViewModel {
                     let result = try await self.fetchUniversityInfoListUseCase.execute()
                     promise(.success(result))
                 } catch {
-                    promise(.failure(.editUniversityFailed))
+                    promise(.failure(.fetchFailed))
                 }
             }
         }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #66 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- `UniversityViewController` 대학교 선택 화면 UI 구현 및 수정 (로딩 화면 추가)
- 지역별 대학교 목록 조회 API 연동 (`Endpoint`, `UseCase`, `Repository`)
- `UniversityViewModel` 에 데이터 바인딩 및 UseCase 의존성 주입 로직 수정
- UI 레이아웃 및 데이터 플로우 관련 버그 수정

<br>

## 📸 스크린샷
|기능|대학교 선택 화면|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/3fbe8331-7b49-43b6-9359-0d084f41cacc" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 지역별 대학교 선택 기능 구현
- UI 및 데이터 흐름: `UniversityViewController` 내부에 `UIHostingController` 를 사용하여 SwiftUI 로 구현된 `InfomationSectionView`를 표시합니다.
- 네트워크 레이어: `UniversityAPIEndpoint` 에 지역별 대학교 목록 조회 API를 정의하고, `UniversityRepositoryImpl` 에서 실제 `NetworkManager` 를 통한 통신 및 디코딩을 수행합니다.
- 상태 관리: `UniversityViewModel` 은 `viewDidLoad` 시점에 `UseCase` 를 통해 대학교 목록을 비동기적으로 가져오며 Combine 스트림을 통해 로딩/결과/에러 상태를 관리합니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
