### PR TITLE
[Feat] #68 - 이용 약관의 웹페이지 연결 로직 구현

### DIFF
--- a/Terbuck/Feature/AuthFeature/Sources/View/TermsListView.swift
+++ b/Terbuck/Feature/AuthFeature/Sources/View/TermsListView.swift
@@ -18,6 +18,7 @@ public final class TermsListView: UIView {
     // MARK: - Combine Properties
     
     let tapPublisher = PassthroughSubject<Bool, Never>()
+    let arrowTapPublisher = PassthroughSubject<Void, Never>()
     
     // MARK: - Enum Properties
     
@@ -55,6 +56,7 @@ public final class TermsListView: UIView {
         setupHierarchy()
         setupLayout()
         setupButtonAction()
+        setupArrowButtonAction()
     }
     
     public required init?(coder: NSCoder) {
@@ -102,8 +104,18 @@ private extension TermsListView {
         checkButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
+    func setupArrowButtonAction() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(arrowTapped))
+        arrowImageView.addGestureRecognizer(tapGesture)
+        arrowImageView.isUserInteractionEnabled = true
+    }
+    
     @objc private func buttonTapped() {
         tapPublisher.send(checkButton.getButtonState())
+    }
+    
+    @objc private func arrowTapped() {
+        arrowTapPublisher.send(())
     }
 }
 

--- a/Terbuck/Feature/AuthFeature/Sources/ViewController/TermsOfServiceViewController.swift
+++ b/Terbuck/Feature/AuthFeature/Sources/ViewController/TermsOfServiceViewController.swift
@@ -73,7 +73,9 @@ private extension TermsOfServiceViewController {
         let input = TermsOfServiceViewModel.Input(
             serviceTermsTapped: serviceTermsView.tapPublisher.eraseToAnyPublisher(),
             userInfoTermsTapped: userInfoTermsView.tapPublisher.eraseToAnyPublisher(),
-            allTermsTapped: allTermsCheckButton.tapPublisher
+            allTermsTapped: allTermsCheckButton.tapPublisher,
+            serviceArrowTapped: serviceTermsView.arrowTapPublisher.eraseToAnyPublisher(),
+            userInfoArrowTapped: userInfoTermsView.arrowTapPublisher.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(input: input)
@@ -122,6 +124,20 @@ private extension TermsOfServiceViewController {
                 guard let self else { return }
                 MixpanelManager.shared.track(eventType: TrackEventType.Signup.firstSignupButtonTapped)
                 self.coordinator?.showUniversity()
+            }
+            .store(in: &cancellables)
+        
+        output.serviceArrowResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.moveWebpage("https://terbuck.notion.site/11905c1258e080ee91cecfb7ff633bab")
+            }
+            .store(in: &cancellables)
+        
+        output.userInfoArrowResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.moveWebpage("https://terbuck.notion.site/11905c1258e08063bba2f82d320de454")
             }
             .store(in: &cancellables)
     }
@@ -204,6 +220,12 @@ private extension TermsOfServiceViewController {
     
     func setupDelegate() {
         
+    }
+    
+    func moveWebpage(_ urlString: String) {
+        guard let url = URL(string: urlString),
+              UIApplication.shared.canOpenURL(url) else { return }
+        UIApplication.shared.open(url, options: [:])
     }
 }
 

--- a/Terbuck/Feature/AuthFeature/Sources/ViewController/TermsOfServiceViewController.swift
+++ b/Terbuck/Feature/AuthFeature/Sources/ViewController/TermsOfServiceViewController.swift
@@ -130,14 +130,14 @@ private extension TermsOfServiceViewController {
         output.serviceArrowResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.moveWebpage("https://terbuck.notion.site/11905c1258e080ee91cecfb7ff633bab")
+                self?.moveWebpage(WebLinkType.service)
             }
             .store(in: &cancellables)
         
         output.userInfoArrowResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.moveWebpage("https://terbuck.notion.site/11905c1258e08063bba2f82d320de454")
+                self?.moveWebpage(WebLinkType.userInfo)
             }
             .store(in: &cancellables)
     }

--- a/Terbuck/Feature/AuthFeature/Sources/ViewModel/TermsOfServiceViewModel.swift
+++ b/Terbuck/Feature/AuthFeature/Sources/ViewModel/TermsOfServiceViewModel.swift
@@ -27,6 +27,8 @@ public class TermsOfServiceViewModel {
         let serviceTermsTapped: AnyPublisher<Bool, Never>
         let userInfoTermsTapped: AnyPublisher<Bool, Never>
         let allTermsTapped: AnyPublisher<Void, Never>
+        let serviceArrowTapped: AnyPublisher<Void, Never>
+        let userInfoArrowTapped: AnyPublisher<Void, Never>
     }
     
     // MARK: - Output
@@ -37,6 +39,8 @@ public class TermsOfServiceViewModel {
         let allTermsResult: AnyPublisher<Bool, Never>
         let mergeTermsResult: AnyPublisher<Bool, Never>
         let isBottomButtonEnabled: AnyPublisher<Bool, Never>
+        let serviceArrowResult: AnyPublisher<Void, Never>
+        let userInfoArrowResult: AnyPublisher<Void, Never>
     }
     
     // MARK: - Init
@@ -100,7 +104,9 @@ public class TermsOfServiceViewModel {
             userInfoTermsResult: userInfoTermsSubject.eraseToAnyPublisher(),
             allTermsResult: allTermsCheckSubject.eraseToAnyPublisher(),
             mergeTermsResult: mergeTermsResult,
-            isBottomButtonEnabled: isButtonEnabled
+            isBottomButtonEnabled: isButtonEnabled,
+            serviceArrowResult: input.serviceArrowTapped,
+            userInfoArrowResult: input.userInfoArrowTapped
         )
     }
 }

--- a/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
@@ -113,16 +113,16 @@ private extension MypageViewController {
                     
                 case .inquiry:
                     MixpanelManager.shared.track(eventType: TrackEventType.Mypage.askMenuButtonTapped)
-                    self?.moveWebpage("http://pf.kakao.com/_BzmZn")
+                    self?.moveWebpage(WebLinkType.inquiry)
                     break
                     
                 case .privacyPolicy:
                     MixpanelManager.shared.track(eventType: TrackEventType.Mypage.personalMenuButtonTapped)
-                    self?.moveWebpage("https://terbuck.notion.site/11905c1258e08063bba2f82d320de454")
+                    self?.moveWebpage(WebLinkType.userInfo)
                     
                 case .serviceGuide:
                     MixpanelManager.shared.track(eventType: TrackEventType.Mypage.serviceMenuButtonTapped)
-                    self?.moveWebpage("https://terbuck.notion.site/11905c1258e080ee91cecfb7ff633bab")
+                    self?.moveWebpage(WebLinkType.service)
                     
                 case .showLogout:
                     MixpanelManager.shared.track(eventType: TrackEventType.Mypage.logoutMenuButtonTapped)

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/MajorInfoViewModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/MajorInfoViewModel.swift
@@ -10,6 +10,29 @@ import Combine
 
 import Shared
 
+enum MajorError: LocalizedError, Equatable {
+    case fetchFailed
+    case signupFailed
+    case notEditUniversity
+    case editUniversityFailed
+    case unknown
+    
+    var errorDescription: String? {
+        switch self {
+        case .fetchFailed:
+            return "대학교 단과대 정보를 불러올 수 없습니다."
+        case .signupFailed:
+            return "가입 관련해서 문제가 발생했어요."
+        case .notEditUniversity:
+            return "대학교 인증 문제가 발생했어요."
+        case .editUniversityFailed:
+            return "대학교 변경 관련해서 문제가 발생했어요."
+        case .unknown:
+            return "알 수 없는 오류가 발생했어요."
+        }
+    }
+}
+
 public class MajorInfoViewModel: ObservableObject {
     
     // MARK: - Properties
@@ -100,7 +123,7 @@ public extension MajorInfoViewModel {
 // MARK: - Private API methods
 
 private extension MajorInfoViewModel {
-    func signupPublisher(_ university: String) -> AnyPublisher<Void, UniversityError> {
+    func signupPublisher(_ university: String) -> AnyPublisher<Void, MajorError> {
         return Future { [weak self] promise in
             guard let self, let signupUseCase else {
                 promise(.failure(.unknown))
@@ -119,7 +142,7 @@ private extension MajorInfoViewModel {
         .eraseToAnyPublisher()
     }
     
-    func editUniversityPublisher(_ university: String) -> AnyPublisher<Void, UniversityError> {
+    func editUniversityPublisher(_ university: String) -> AnyPublisher<Void, MajorError> {
         return Future { [weak self] promise in
             guard let self, let editUniversityUseCase else {
                 promise(.failure(.unknown))

--- a/Terbuck/Shared/Sources/Enum/WebLinkType.swift
+++ b/Terbuck/Shared/Sources/Enum/WebLinkType.swift
@@ -1,0 +1,14 @@
+//
+//  WebLinkType.swift
+//  Shared
+//
+//  Created by ParkJunHyuk on 9/9/25.
+//
+
+import Foundation
+
+public enum WebLinkType {
+    public static let service = "https://terbuck.notion.site/11905c1258e080ee91cecfb7ff633bab"
+    public static let userInfo = "https://terbuck.notion.site/11905c1258e08063bba2f82d320de454"
+    public static let inquiry = "http://pf.kakao.com/_BzmZn"
+}


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #68 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 이용약관 View 의 `arrowImageView` 에 `arrowTapPublisher` 으로 연결
- `MajorViewModel` 에 `MajorError` 에러 케이스를 위한 enum 정의

<br>

## 📸 스크린샷
|기능|서비스 이용약관|개인정보|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/dff9e216-d7d7-413b-af9c-68d54ff62223" width ="250">|<img src = "https://github.com/user-attachments/assets/cbc12f16-0a09-4bc4-be01-3b46f9bdcdb6" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

###  1. 이용약관 상세 보기 기능 추가
- `TermsListView` 내의 `arrowImageView` 에 `UITapGestureRecognizer` 를 추가하여 사용자 입력을 감지합니다.
- 탭 이벤트가 발생하면 Combine 프레임워크의 `PassthroughSubject` 로 선언된 `arrowTapPublisher` 를 통해 이벤트 스트림을 방출합니다.
- `TermsOfServiceViewController` 에서는 해당 `publisher` 를 구독하고, 이벤트가 수신되면 `moveWebpage()` 메서드를 호출하여 약관 별 URL로 이동시킵니다.

<br>

### 2. 단과대 선택 화면 에러 핸들링 개선
- `MajorInfoViewModel` 에서 발생할 수 있는 에러 케이스를 보다 명확하게 관리하기 위해 `MajorError` 라는 enum 타입을 새로 정의했습니다.
- 기존에 포괄적으로 사용되던 `UniversityError` 를 `MajorError` 로 교체하여 회원가입 및 대학교 변경 과정에서 발생하는 에러를 더 상세하게 분기 처리하도록 개선했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
