### PR TITLE
[Feat] #73 - 학생증 심사여부 API 적용 및 로직 분기처리 리펙토링

### DIFF
--- a/Terbuck/Core/CoreNetwork/Sources/Member/DTO/Response/ApprovedStudentIdStatusResponseDTO.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/Member/DTO/Response/ApprovedStudentIdStatusResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  ApprovedStudentIdStatusResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 9/19/25.
+//
+
+import Foundation
+
+public struct ApprovedStudentIdStatusResponseDTO: Decodable {
+    public let isPending: Bool
+}

--- a/Terbuck/Core/CoreNetwork/Sources/Member/MemberAPIEndpoint.swift
+++ b/Terbuck/Core/CoreNetwork/Sources/Member/MemberAPIEndpoint.swift
@@ -14,6 +14,7 @@ public enum MemberAPIEndpoint {
     case getStudentId
     case putRegisterStudentId(RegisterStudentIDRequestDTO)
     case deleteStudentId
+    case getApprovedStudentIdStatus
 }
 
 extension MemberAPIEndpoint: EndpointProtocol {
@@ -31,6 +32,8 @@ extension MemberAPIEndpoint: EndpointProtocol {
             return basePath.rawValue + "/univ"
         case .getStudentId, .putRegisterStudentId, .deleteStudentId:
             return basePath.rawValue + "/studentID"
+        case .getApprovedStudentIdStatus:
+            return basePath.rawValue + "/studentID/pending"
         }
     }
     
@@ -40,7 +43,7 @@ extension MemberAPIEndpoint: EndpointProtocol {
             return .post
         case .patchUniversity:
             return .patch
-        case .getStudentId:
+        case .getStudentId, .getApprovedStudentIdStatus:
             return .get
         case .putRegisterStudentId:
             return .put

--- a/Terbuck/DesignSystem/Sources/ToastMessage/ToastMessageView.swift
+++ b/Terbuck/DesignSystem/Sources/ToastMessage/ToastMessageView.swift
@@ -27,7 +27,7 @@ final class ToastMessageView: UIView {
         
         setupStyle(type)
         setupHierarchy()
-        setupLayout()
+        setupLayout(type)
     }
     
     required init?(coder: NSCoder) {
@@ -81,12 +81,18 @@ private extension ToastMessageView {
         self.addSubview(titleStackView)
     }
     
-    func setupLayout() {
+    func setupLayout(_ type: ToastType) {
         titleStackView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(16)
+            
+            switch type {
+            case .approvedStudentCard(_), .moreBenefit:
+                $0.centerX.equalToSuperview()
+            default:
+                $0.horizontalEdges.equalToSuperview().inset(16)
+            }
         }
-
+        
         iconImageView.snp.makeConstraints {
             $0.size.equalTo(16)
         }

--- a/Terbuck/DesignSystem/Sources/ToastMessage/ToastType.swift
+++ b/Terbuck/DesignSystem/Sources/ToastMessage/ToastType.swift
@@ -12,7 +12,7 @@ public enum AuthorizedType {
     case detailStore
 }
 
-public enum ToastType {
+public enum ToastType: Equatable {
     case notAuthorized(type: AuthorizedType)
     case noticeStudentCard
     case alarmStudentCard
@@ -20,6 +20,7 @@ public enum ToastType {
     case moreBenefit
     case partnership
     case requestPartnership
+    case approvedStudentCard(type: AuthorizedType)
     
     var image: UIImage? {
         switch self {
@@ -41,7 +42,7 @@ public enum ToastType {
         case .partnership:
             return .moreBenefitIcon
              
-        case .requestPartnership:
+        case .requestPartnership, .approvedStudentCard:
             return nil
         }
     }
@@ -68,6 +69,9 @@ public enum ToastType {
             
         case .requestPartnership:
             return "업데이트 되는대로 알려드릴게요 :)"
+            
+        case .approvedStudentCard:
+            return "학생증을 확인 중이에요. 잠시만 기다려주세요 :)"
         }
     }
     
@@ -109,6 +113,13 @@ public enum ToastType {
             
         case .partnership:
             return 75
+            
+        case .approvedStudentCard(let type):
+            if type == .detailStore {
+                return 68
+            } else {
+                return 16
+            }
             
         default:
             return 16

--- a/Terbuck/Feature/HomeFeature/Sources/Data/HomeRepositoryImpl.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/Data/HomeRepositoryImpl.swift
@@ -16,6 +16,7 @@ public protocol HomeRepository {
     func getPartnershipDisclosureStatus(universityName: String) async throws -> Bool
     func postPartnershipDisclosureRequest(universityName: String) async throws
     func getDisclosureRequestStatus(universityName: String) async throws -> Bool
+    func getApprovedStudentIdStatus() async throws -> Bool
 }
 
 struct HomeRepositoryImpl: HomeRepository {
@@ -65,5 +66,10 @@ struct HomeRepositoryImpl: HomeRepository {
         let requestDTO = MyUniversityRequestDTO(universityName: universityName)
         
         return try await networkManager.request(UniversityAPIEndpoint.getDisclosureRequestStatus(requestDTO))
+    }
+    
+    func getApprovedStudentIdStatus() async throws -> Bool {
+        let dto: ApprovedStudentIdStatusResponseDTO = try await networkManager.request(MemberAPIEndpoint.getApprovedStudentIdStatus)
+        return dto.isPending
     }
 }

--- a/Terbuck/Feature/HomeFeature/Sources/Domain/FetchApprovedStudentIdStatusUseCase.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/Domain/FetchApprovedStudentIdStatusUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchApprovedStudentIdStatusUseCase.swift
+//  HomeFeature
+//
+//  Created by ParkJunHyuk on 9/19/25.
+//
+
+import Foundation
+import Shared
+
+public protocol FetchApprovedStudentIdStatusUseCase {
+    func execute() async throws -> Bool
+}
+
+public struct FetchApprovedStudentIdStatusUseCaseImpl: FetchApprovedStudentIdStatusUseCase {
+    private let repository: HomeRepository
+
+    public init(repository: HomeRepository) {
+        self.repository = repository
+    }
+
+    public func execute() async throws -> Bool {
+        return try await repository.getApprovedStudentIdStatus()
+    }
+}

--- a/Terbuck/Feature/HomeFeature/Sources/Factory/HomeFactoryImpl.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/Factory/HomeFactoryImpl.swift
@@ -22,7 +22,8 @@ public final class HomeFactoryImpl: HomeFactory {
             searchPartnershipUseCase: SearchPartnershipUseCaseImpl(repository: HomeRepositoryImpl()),
             fetchPartnershipDisclosureStatusUseCase: FetchPartnershipDisclosureStatusUseCaseImpl(repository: HomeRepositoryImpl()),
             requestPartnershipDisclosureUseCase: RequestPartnershipDisclosureUseCaseImpl(repository: HomeRepositoryImpl()),
-            fetchDisclosureRequestStatusUseCase: FetchDisclosureRequestStatusUseCaseImpl(repository: HomeRepositoryImpl())
+            fetchDisclosureRequestStatusUseCase: FetchDisclosureRequestStatusUseCaseImpl(repository: HomeRepositoryImpl()),
+            fetchApprovedStudentIdStatusUseCase: FetchApprovedStudentIdStatusUseCaseImpl(repository: HomeRepositoryImpl())
         )
         
         return HomeViewController(

--- a/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
@@ -115,22 +115,25 @@ private extension HomeViewController {
         
         output.studentIDCardButtonResult
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] authResult in
+            .sink { [weak self] action in
                 guard let self else { return }
                 
-                if authResult == true {
-                    self.coordinator?.startRegisterStudentCard(for: .auth, location: nil)
-                    
-                } else if authResult == false && !UserDefaultsManager.shared.bool(for: .isOnboarding) {
+                switch action {
+                case .showOnboarding:
                     guard let holeLocation = self.holeLocation else { return }
                     self.coordinator?.startRegisterStudentCard(for: .onboarding, location: holeLocation)
                     UserDefaultsManager.shared.set(true, for: .isOnboarding)
                     
-                } else {
-                    MixpanelManager.shared.track(eventType: TrackEventType.Home.registerButtonInToastMessage)
+                case .pendingMessage:
+                    ToastManager.shared.showToast(from: self, type: .approvedStudentCard(type: .home))
+                    
+                case .registerMessage:
                     ToastManager.shared.showToast(from: self, type: .notAuthorized(type: .home)) {
                         self.coordinator?.startRegisterStudentCard(for: .register, location: nil)
                     }
+                    
+                case .showStudentCard:
+                    self.coordinator?.startRegisterStudentCard(for: .auth, location: nil)
                 }
             }
             .store(in: &cancellables)

--- a/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
@@ -35,6 +35,7 @@ public final class HomeViewModel {
     private let fetchPartnershipDisclosureStatusUseCase: FetchPartnershipDisclosureStatusUseCase
     private let requestPartnershipDisclosureUseCase: RequestPartnershipDisclosureUseCase
     private let fetchDisclosureRequestStatusUseCase: FetchDisclosureRequestStatusUseCase
+    private let fetchApprovedStudentIdStatusUseCase: FetchApprovedStudentIdStatusUseCase
     
     // MARK: - Private Combine Publishers Properties
     
@@ -61,7 +62,7 @@ public final class HomeViewModel {
     // MARK: - Output
     
     struct Output {
-        let studentIDCardButtonResult: AnyPublisher<Bool, Never>
+        let studentIDCardButtonResult: AnyPublisher<AuthStudentCardType, Never>
         let authStudentResult: AnyPublisher<Bool?, Never>
         let homeError: AnyPublisher<HomeError, Never>
     }
@@ -73,13 +74,15 @@ public final class HomeViewModel {
         searchPartnershipUseCase: SearchPartnershipUseCase,
         fetchPartnershipDisclosureStatusUseCase: FetchPartnershipDisclosureStatusUseCase,
         requestPartnershipDisclosureUseCase: RequestPartnershipDisclosureUseCase,
-        fetchDisclosureRequestStatusUseCase: FetchDisclosureRequestStatusUseCase
+        fetchDisclosureRequestStatusUseCase: FetchDisclosureRequestStatusUseCase,
+        fetchApprovedStudentIdStatusUseCase: FetchApprovedStudentIdStatusUseCase
     ) {
         self.searchStoreUseCase = searchStoreUseCase
         self.searchPartnershipUseCase = searchPartnershipUseCase
         self.fetchPartnershipDisclosureStatusUseCase = fetchPartnershipDisclosureStatusUseCase
         self.requestPartnershipDisclosureUseCase = requestPartnershipDisclosureUseCase
         self.fetchDisclosureRequestStatusUseCase = fetchDisclosureRequestStatusUseCase
+        self.fetchApprovedStudentIdStatusUseCase = fetchApprovedStudentIdStatusUseCase
     }
     
     // MARK: - Public methods
@@ -120,12 +123,33 @@ public final class HomeViewModel {
             .store(in: &cancellables)
         
         let studentIDCardButtonResult = input.studentIDCardButtonTap
-            .handleEvents(receiveOutput : { _ in
+            .handleEvents(receiveOutput: { _ in
                 MixpanelManager.shared.track(eventType: TrackEventType.Home.studentCardButtonTapped)
             })
-            .map { [weak self] _ -> Bool in
-                guard let self, let result = isAuthStudentSubject.value else { return false }
-                return result
+            .flatMap { [weak self] _ -> AnyPublisher<(isAuth: Bool, isPending: Bool), Never> in
+                guard let self = self else {
+                    return Just((isAuth: false, isPending: false)).eraseToAnyPublisher()
+                }
+                
+                let isAuthPublisher = self.isAuthStudentSubject.compactMap { $0 }.first()
+                let isPendingPublisher = self.fetchApprovedStudentIdStatusPublisher().catch { _ in Just(false) }
+                    
+                return Publishers.Zip(isAuthPublisher, isPendingPublisher)
+                    .map { (isAuth: $0.0, isPending: $0.1) }
+                    .eraseToAnyPublisher()
+            }
+            .map { (isAuth, isPending) -> AuthStudentCardType in
+                if isAuth {
+                    return .showStudentCard
+                }
+                
+                if isPending {
+                    return .pendingMessage
+                }
+                
+                // 인증도, 심사중도 아닐 때만 온보딩 여부를 확인
+                let hasCompletedOnboarding = UserDefaultsManager.shared.bool(for: .isOnboarding)
+                return hasCompletedOnboarding ? .registerMessage : .showOnboarding
             }
             .eraseToAnyPublisher()
         
@@ -412,6 +436,25 @@ private extension HomeViewModel {
                 do {
                     let result = try await self.fetchDisclosureRequestStatusUseCase.execute(universityName: universityName)
                     
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(.serverFailed))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    func fetchApprovedStudentIdStatusPublisher() -> AnyPublisher<Bool, HomeError> {
+        return Future { [weak self] promise in
+            guard let self else {
+                promise(.failure(.unknown))
+                return
+            }
+            
+            Task {
+                do {
+                    let result = try await self.fetchApprovedStudentIdStatusUseCase.execute()
                     promise(.success(result))
                 } catch {
                     promise(.failure(.serverFailed))

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
@@ -104,14 +104,23 @@ public final class RegisterStudentCardViewModel {
                 }
 
                 return self.putStudentCardPublisher()
-                    .handleEvents(receiveOutput: { _ in
-                        guard let imageData = self.studentImageData else { return }
-                        
-                        let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
-                    })
+//                    .handleEvents(receiveOutput: { _ in
+//                        guard let imageData = self.studentImageData else { return }
+//                        
+//                        let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
+//                    })
                     .catch { _ in Just(false).eraseToAnyPublisher() }
                     .eraseToAnyPublisher()
             }
+            .handleEvents(receiveOutput: { [weak self] isSuccess in
+                if isSuccess {
+//                    guard let imageData = self?.studentImageData else { return }
+//                    let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
+                    
+                    UserDefaultsManager.shared.set(false, for: .isStudentIDAuthenticated)
+                    FileStorageManager.shared.delete(type: .studentIdCard)
+                }
+            })
             .eraseToAnyPublisher()
         
         return Output(

--- a/Terbuck/Feature/StoreFeature/Sources/Data/StoreRepositoryImpl.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Data/StoreRepositoryImpl.swift
@@ -13,6 +13,7 @@ import CoreNetwork
 public protocol StoreRepository {
     func getSearchStoreMap(university: String, category: String, latitude: String, longitude: String) async throws -> [SearchStoreMapEntity]
     func getSearchDetailStore(storeId: Int) async throws -> SearchDetailStoreEntity
+    func getApprovedStudentIdStatus() async throws -> Bool
 }
 
 struct StoreRepositoryImpl: StoreRepository {
@@ -30,5 +31,10 @@ struct StoreRepositoryImpl: StoreRepository {
         let dto: SearchStoreDetailResponseDTO = try await networkManager.request(StoreAPIEndpoint.getDetailStore(requestDTO))
         
         return dto.toEntity()
+    }
+    
+    func getApprovedStudentIdStatus() async throws -> Bool {
+        let dto: ApprovedStudentIdStatusResponseDTO = try await networkManager.request(MemberAPIEndpoint.getApprovedStudentIdStatus)
+        return dto.isPending
     }
 }

--- a/Terbuck/Feature/StoreFeature/Sources/Domain/FetchApprovedStudentIdStatusUseCase.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Domain/FetchApprovedStudentIdStatusUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchApprovedStudentIdStatusUseCase.swift
+//  StoreFeature
+//
+//  Created by ParkJunHyuk on 9/20/25.
+//
+
+import Foundation
+import Shared
+
+public protocol FetchApprovedStudentIdStatusUseCase {
+    func execute() async throws -> Bool
+}
+
+public struct FetchApprovedStudentIdStatusUseCaseImpl: FetchApprovedStudentIdStatusUseCase {
+    private let repository: StoreRepository
+
+    public init(repository: StoreRepository) {
+        self.repository = repository
+    }
+
+    public func execute() async throws -> Bool {
+        return try await repository.getApprovedStudentIdStatus()
+    }
+}

--- a/Terbuck/Feature/StoreFeature/Sources/Factory/DetailStoreFactoryImpl.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Factory/DetailStoreFactoryImpl.swift
@@ -23,7 +23,8 @@ public final class DetailStoreFactoryImpl: DetailStoreFactory {
                 storeId: storeId,
                 searchDetailStoreUseCase: SearchDetailStoreUseCaseImpl(
                     repository: StoreRepositoryImpl()
-                )
+                ),
+                fetchApprovedStudentIdStatusUseCase: FetchApprovedStudentIdStatusUseCaseImpl(repository: StoreRepositoryImpl())
             ),
             coordinator: coordinator
         )

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
@@ -58,7 +58,7 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
 
         Task {
             await detailStoreViewModel.fetchDetailStoreBenefitData()
-            try await detailStoreViewModel.fetchApprovedStudentIdStatus()
+            await detailStoreViewModel.fetchApprovedStudentIdStatus()
         }
     }
     

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
@@ -58,6 +58,7 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
 
         Task {
             await detailStoreViewModel.fetchDetailStoreBenefitData()
+            try await detailStoreViewModel.fetchApprovedStudentIdStatus()
         }
     }
     
@@ -114,6 +115,8 @@ private extension DetailStoreInfoViewController {
             MixpanelManager.shared.track(eventType: TrackEventType.DetailStore.studentCardButtonTapped)
             if UserDefaultsManager.shared.bool(for: .isStudentIDAuthenticated) {
                 self.coordinator?.startRegisterStudentCard(for: .auth, location: nil)
+            } else if self.detailStoreViewModel.pendingMessage == true {
+                ToastManager.shared.showToast(from: self, type: .approvedStudentCard(type: .detailStore))
             } else {
                 ToastManager.shared.showToast(from: self, type: .notAuthorized(type: .detailStore)) {
                     self.coordinator?.startRegisterStudentCard(for: .register, location: nil)

--- a/Terbuck/Feature/StoreFeature/Sources/ViewModel/DetailStoreInfoViewModel.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewModel/DetailStoreInfoViewModel.swift
@@ -41,19 +41,23 @@ public final class DetailStoreInfoViewModel: PreviewImageDisplayable {
     
     public var selectedBenefitIndex: Int? = nil
     public var isShowModal = false
+    public var pendingMessage = false
     public var onUseagesListModalChanged: ((Bool) -> Void)?
     
     private let searchDetailStoreUseCase: SearchDetailStoreUseCase
+    private let fetchApprovedStudentIdStatusUseCase: FetchApprovedStudentIdStatusUseCase
     private let storeId: Int
     
     // MARK: - Init
     
     public init(
         storeId: Int,
-        searchDetailStoreUseCase: SearchDetailStoreUseCase
+        searchDetailStoreUseCase: SearchDetailStoreUseCase,
+        fetchApprovedStudentIdStatusUseCase: FetchApprovedStudentIdStatusUseCase
     ) {
         self.storeId = storeId
         self.searchDetailStoreUseCase = searchDetailStoreUseCase
+        self.fetchApprovedStudentIdStatusUseCase = fetchApprovedStudentIdStatusUseCase
     }
 }
 
@@ -88,6 +92,16 @@ public extension DetailStoreInfoViewModel {
                                             title: titleModel.storeName,
                                             images: imageModel.map { $0.imageURL })
     }
+    
+    func fetchApprovedStudentIdStatus() async throws {
+        do {
+            let result = try await self.fetchApprovedStudentIdStatusUseCase.execute()
+            self.pendingMessage = result
+        } catch (let error) {
+            print(error.localizedDescription)
+            throw error
+        }
+    }
 }
 
 // MARK: - Private API Extension
@@ -95,7 +109,6 @@ public extension DetailStoreInfoViewModel {
 private extension DetailStoreInfoViewModel {    
     func getDetailStoreData() async throws -> StoreBenefitResult {
         do {
-            
             let result = try await self.searchDetailStoreUseCase.execute(storeId: storeId)
             
             storeURL = result.3

--- a/Terbuck/Feature/StoreFeature/Sources/ViewModel/DetailStoreInfoViewModel.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewModel/DetailStoreInfoViewModel.swift
@@ -93,13 +93,13 @@ public extension DetailStoreInfoViewModel {
                                             images: imageModel.map { $0.imageURL })
     }
     
-    func fetchApprovedStudentIdStatus() async throws {
+    func fetchApprovedStudentIdStatus() async {
         do {
             let result = try await self.fetchApprovedStudentIdStatusUseCase.execute()
             self.pendingMessage = result
         } catch (let error) {
+            // TODO: 추후 에러 정책이 정해지면 알맞은 로깅 또는 에러 상태값 변경 로직 추가
             print(error.localizedDescription)
-            throw error
         }
     }
 }

--- a/Terbuck/Shared/Sources/Enum/AuthStudentCardType.swift
+++ b/Terbuck/Shared/Sources/Enum/AuthStudentCardType.swift
@@ -1,0 +1,26 @@
+//
+//  AuthStudentCardType.swift
+//  Shared
+//
+//  Created by ParkJunHyuk on 9/19/25.
+//
+
+import Foundation
+
+/// 학생증 버튼 탭 액션을 정의하는 타입
+///
+/// 사용자의 인증 상태, 온보딩 여부, 심사 상태에 따라 분기되며
+/// ViewModel이 이 타입을 반환하면, ViewController는 해당하는 화면으로 이동하거나 메시지를 표시합니다.
+public enum AuthStudentCardType {
+    /// 미인증 사용자가 학생증 버튼 온보딩을 아직 보지 않은 경우
+    case showOnboarding
+    
+    /// 미인증 사용자가 온보딩을 이미 완료한 경우, 등록을 유도
+    case registerMessage
+    
+    /// 학생증을 제출하여 심사가 진행 중인 경우
+    case pendingMessage
+    
+    /// 학생증 인증이 완료된 사용자의 경우
+    case showStudentCard
+}


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #73 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 학생증 심사 상태 확인 API Endpoint 추가 (GET /studentID/pending)
- 학생증 심사 상태 확인을 위한 `UseCase` 및 `Repository` 계층 구현
- `HomeViewModel` 의 학생증 버튼 탭 로직을 `AuthStudentCardType` 분기 처리로 리팩토링
- 홈 화면에 학생증 '심사중' 상태에 대한 토스트 메시지 UI 반영
- 제휴업체 상세 화면에 학생증 '심사중' 상태 확인 로직 및 UI 반영
- 학생증 제출 완료 시 로컬 데이터 처리 로직 개선

<br>

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/4495f93e-9b7b-4a49-8ab8-d426e0fcf947" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 학생증 심사중 상태 처리 기능 추가
기존에는 학생증 인증 여부(true/false)만 확인했지만 사용자가 학생증을 제출한 후 심사가 완료되기 전까지의 '심사중' 상태를 처리하는 기능이 추가되었습니다. 이를 위해 `MemberAPIEndpoint` 에 새로운 API가 추가되었고, 관련 `UseCase` 와 `Repository` 가 구현되었습니다.

<br>

### 2. HomeViewModel 로직 리팩토링

HomeViewModel에서 학생증 버튼 탭 시의 분기 처리 로직을 대폭 개선했습니다.
- AS-IS: `ViewController` 에서 Bool 값을 받아 `if/else` 로 분기 처리
- TO-BE: `ViewModel` 이 `AuthStudentCardType` 이라는 명확한 `Action` 을 반환하고 `ViewController` 는 switch문으로 이를 실행만 하도록 변경

이를 통해 ViewModel 의 역할이 명확해지고 ViewController 의 코드가 아래와 같이 간결해졌습니다.

``` swift
output.studentIDCardButtonResult
    .receive(on: DispatchQueue.main)
    .sink { [weak self] action in
        guard let self else { return }
        
        switch action {
        case .showOnboarding:
            // ... 온보딩 화면 표시
            
        case .pendingMessage:
            // ... 심사중 토스트 표시
            
        case .registerMessage:
            // ... 등록 유도 토스트 표시

        case .showStudentCard:
            // ... 학생증 화면으로 이동
        }
    }
    .store(in: &cancellables)
```

<br>

### 3. 학생증 제출 후 처리 로직 개선
`RegisterStudentCardViewModel` 에서 학생증 제출이 성공하면(`putStudentCardPublisher` 결과가 `true` 이면) `handleEvents` 를 통해 즉시 관련 `UserDefaults` 값을 업데이트하고 로컬에 저장된 학생증 이미지를 삭제하도록 수정했습니다. 이를 통해 상태 불일치 가능성을 줄였습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
