### PR TITLE
[Refactor] #78 - iOS 26 관련 하단 탭바 UI 대응

### DIFF
--- a/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
+++ b/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
@@ -64,7 +64,6 @@ public final class CustomTabBar: UITabBar {
 private extension CustomTabBar {
     @objc func tabButtonTapped(_ sender: UIButton) {
         onButtonTapped?(sender.tag)
-        updateSelectedIndex(to: sender.tag)
     }
     
     func setupStyle() {

--- a/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
+++ b/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
@@ -18,6 +18,7 @@ public final class CustomTabBar: UITabBar {
     
     private var selectedIndex: Int = 0
     public var onTabSelected: ((TabBarType) -> Void)?
+    public var onButtonTapped: ((Int) -> Void)?
     
     // MARK: - UI Components
     
@@ -61,6 +62,11 @@ public final class CustomTabBar: UITabBar {
 // MARK: - Private Extensions
 
 private extension CustomTabBar {
+    @objc func tabButtonTapped(_ sender: UIButton) {
+        onButtonTapped?(sender.tag)
+        updateSelectedIndex(to: sender.tag)
+    }
+    
     func setupStyle() {
         self.backgroundColor = DesignSystem.Color.uiColor(.terbuckWhite)
         
@@ -118,6 +124,7 @@ private extension CustomTabBar {
         
         let button = UIButton(configuration: config)
         button.tag = type.rawValue
+        button.addTarget(self, action: #selector(tabButtonTapped), for: .touchUpInside)
 
         return button
     }

--- a/Terbuck/DesignSystem/Sources/Components/CustomTabBarController.swift
+++ b/Terbuck/DesignSystem/Sources/Components/CustomTabBarController.swift
@@ -19,9 +19,41 @@ public final class CustomTabBarController: UITabBarController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        delegate = self
         
         setupStyle()
+        tabBar.isHidden = true
+
+        view.addSubview(customTabBarView)
+        view.clipsToBounds = true // transform으로 이동한 뷰가 부모 bounds 밖으로 나가면 숨김
+        
+        customTabBarView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        updateSafeAreaInsetsForAllViewControllers()
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.tabBar.isHidden = true
+    }
+    
+    // MARK: - Methods
+    
+    public func hideTabBar() {
+        self.customTabBarView.isHidden = true
+        self.view.setNeedsLayout()
+    }
+    
+    public func showTabBar() {
+        self.customTabBarView.isHidden = false
+        self.view.setNeedsLayout()
     }
 }
 
@@ -29,16 +61,40 @@ public final class CustomTabBarController: UITabBarController {
 
 private extension CustomTabBarController {
     func setupStyle() {
-        setValue(customTabBarView, forKey: "tabBar")
-    }
-}
+        customTabBarView.onButtonTapped = { [weak self] index in
+            guard let self = self else { return }
 
-// UITabBarControllerDelegate 구현
-extension CustomTabBarController: UITabBarControllerDelegate {
-    public func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        self.customTabBarView.updateSelectedIndex(to: selectedIndex)
+            // 1. 탭 인덱스 변경
+            self.selectedIndex = index
+            
+            // 2. 탭바 UI 업데이트
+            self.customTabBarView.updateSelectedIndex(to: index)
+            
+            // 3. 햅틱 피드백
+            self.hapticGenerator.impactOccurred()
+            
+            // 4. 안전 영역 업데이트
+            self.updateSafeAreaInsetsForAllViewControllers()
+        }
+    }
+    
+    /// 모든 자식 뷰컨트롤러의 Safe Area Inset을 업데이트합니다.
+    func updateSafeAreaInsetsForAllViewControllers() {
+        let isTabBarHidden = customTabBarView.isHidden
         
-        // 햅틱 피드백
-        hapticGenerator.impactOccurred()
+        self.viewControllers?.forEach { viewController in
+            // 탭바가 숨겨져 있다면, 모든 VC의 inset을 0으로 설정
+            if isTabBarHidden {
+                viewController.additionalSafeAreaInsets.bottom = 0
+            } else {
+                // 탭바가 보일 때만 기존 로직을 실행
+                if viewController == self.selectedViewController {
+                    let overlapHeight = customTabBarView.frame.height - view.safeAreaInsets.bottom
+                    viewController.additionalSafeAreaInsets.bottom = overlapHeight
+                } else {
+                    viewController.additionalSafeAreaInsets.bottom = 0
+                }
+            }
+        }
     }
 }

--- a/Terbuck/DesignSystem/Sources/Extension/UIVeiwController+Terbuck.swift
+++ b/Terbuck/DesignSystem/Sources/Extension/UIVeiwController+Terbuck.swift
@@ -143,6 +143,20 @@ public extension UIViewController {
     }
 }
 
+public extension UIViewController {
+    /// CustomTabBarController의 탭바를 숨깁니다.
+    func hideCustomTabBar() {
+        guard let customTabBarController = self.tabBarController as? CustomTabBarController else { return }
+        customTabBarController.hideTabBar()
+    }
+    
+    /// CustomTabBarController의 탭바를 보여줍니다
+    func showCustomTabBar() {
+        guard let customTabBarController = self.tabBarController as? CustomTabBarController else { return }
+        customTabBarController.showTabBar()
+    }
+}
+
 public extension UIView {
     // firstResponder를 쉽게 찾기 위한 UIView extension
     var firstResponder: UIView? {

--- a/Terbuck/Feature/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/Terbuck/Feature/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -52,7 +52,6 @@ public final class AuthCoordinator: BaseCoordinator, AuthCoordinating {
         guard let signupViewModel else { return }
         
         let termsOfServiceVC = termsFactory.makeTermsViewController(coordinator: self, viewModel: signupViewModel)
-        termsOfServiceVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(termsOfServiceVC, animated: true)
     }
     

--- a/Terbuck/Feature/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
@@ -58,7 +58,6 @@ public class HomeCoordinator: HomeCoordinating, PoppableCoordinator {
             partnershipId: partnershipId
         )
         
-        partnershipVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(partnershipVC, animated: true)
     }
     
@@ -82,8 +81,6 @@ public class HomeCoordinator: HomeCoordinating, PoppableCoordinator {
 extension HomeCoordinator: AlarmSettingCoordinating {
     public func showAlarmSetting() {
         let alarmSettingVC = alarmSettingFactory.makeAlarmSettingViewController(coordinator: self)
-        
-        alarmSettingVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(alarmSettingVC, animated: true)
     }
 }

--- a/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
@@ -92,6 +92,7 @@ final class HomeViewController: UIViewController {
         super.viewWillAppear(animated)
         
         viewLifeCycleSubject.send(.viewWillAppear)
+        self.showCustomTabBar()
     }
     
     override func viewDidLayoutSubviews() {

--- a/Terbuck/Feature/HomeFeature/Sources/ViewController/PartnershipViewController.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewController/PartnershipViewController.swift
@@ -49,10 +49,16 @@ final class PartnershipViewController: UIViewController, UIGestureRecognizerDele
         setupStyle()
         setupHierarchy()
         setupLayout()
-
+        
         Task {
             await partnershipViewModel.fetchPartnershipData()
         }
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.hideCustomTabBar()
     }
 }
 

--- a/Terbuck/Feature/MypageFeature/Sources/Coordinator/MypageCoordinator.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/Coordinator/MypageCoordinator.swift
@@ -88,8 +88,6 @@ public class MypageCoordinator: BaseCoordinator, MypageCoordinating {
 extension MypageCoordinator: AlarmSettingCoordinating {
     public func showAlarmSetting() {
         let alarmSettingVC = alarmSettingFactory.makeAlarmSettingViewController(coordinator: self)
-        
-        alarmSettingVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(alarmSettingVC, animated: true)
     }
 }

--- a/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
@@ -70,6 +70,7 @@ public final class MypageViewController: UIViewController {
         super.viewWillAppear(animated)
         
         viewLifeCycleSubject.send(.viewWillAppear)
+        self.self.showCustomTabBar()
     }
 }
 

--- a/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
+++ b/Terbuck/Feature/MypageFeature/Sources/ViewController/MypageViewController.swift
@@ -70,7 +70,7 @@ public final class MypageViewController: UIViewController {
         super.viewWillAppear(animated)
         
         viewLifeCycleSubject.send(.viewWillAppear)
-        self.self.showCustomTabBar()
+        self.showCustomTabBar()
     }
 }
 

--- a/Terbuck/Feature/NotificationSettingFeature/Sources/ViewController/AlarmSettingViewControllor.swift
+++ b/Terbuck/Feature/NotificationSettingFeature/Sources/ViewController/AlarmSettingViewControllor.swift
@@ -67,6 +67,7 @@ public final class AlarmSettingViewControllor: UIViewController, UIGestureRecogn
         super.viewWillAppear(animated)
         
         viewLifeCycleSubject.send(.viewWillAppear)
+        self.hideCustomTabBar()
     }
 }
 

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/Coordinator/RegisterStudentCardCoordinator.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/Coordinator/RegisterStudentCardCoordinator.swift
@@ -60,7 +60,6 @@ final class RegisterStudentCardCoordinator: RegisterStudentCardCoordinating, Pop
     func showRegisterStudentCard() {
         let registerStudentIDCardVC = registerStudentCardFactory.makeRegisterStudentCardViewController(coordinator: self)
         self.rootViewController = registerStudentIDCardVC
-        registerStudentIDCardVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(registerStudentIDCardVC, animated: true)
     }
     

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewController/RegisterStudentCardViewController.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewController/RegisterStudentCardViewController.swift
@@ -77,6 +77,12 @@ public final class RegisterStudentCardViewController: UIViewController, UIGestur
         setupKeyboardHandling()
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.hideCustomTabBar()
+    }
+    
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         

--- a/Terbuck/Feature/StoreFeature/Sources/Coordinator/StoreCoordinator.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/Coordinator/StoreCoordinator.swift
@@ -55,14 +55,12 @@ public class StoreCoordinator: StoreCoordinating {
     
     public func showDetailStoreInfo(storeId: Int) {
         let detailStoreVC = detailStoreFactory.makeDetailStoreViewController(coordinator: self, storeId: storeId)
-        detailStoreVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(detailStoreVC, animated: true)
     }
     
     public func searchStore() {
         let searchStoreVC = searchStoreFactory.makeSearchStoreViewController(storeMapViewModel: storeMapViewModel, coordinator: self)
         searchStoreVC.modalPresentationStyle = .overFullScreen
-        searchStoreVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(searchStoreVC, animated: false)
     }
     

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
@@ -60,12 +60,20 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
             await detailStoreViewModel.fetchDetailStoreBenefitData()
             await detailStoreViewModel.fetchApprovedStudentIdStatus()
         }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            ToastManager.shared.showToast(from: self, type: .moreBenefit)
+        }
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.hideCustomTabBar()
     }
     
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        ToastManager.shared.showToast(from: self, type: .moreBenefit)
         
         detailStoreViewModel.onUseagesListModalChanged = { [weak self] isPresented in
             if isPresented {

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/DetailStoreInfoViewController.swift
@@ -27,6 +27,7 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
     private let customNavBar = CustomNavigationView(type: .benefitStore, title: "제휴 혜택")
     private let naverMovementButton = DesignSystem.Button.naverMovementButton()
     private var hostingController: UIHostingController<DetailStoreInfoView>!
+    private var toastHasBeenShown = false
     
     private let backgroundView = UIView()
     private var bottomSheetVC: DetailBenefitListModalViewController?
@@ -60,10 +61,6 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
             await detailStoreViewModel.fetchDetailStoreBenefitData()
             await detailStoreViewModel.fetchApprovedStudentIdStatus()
         }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            ToastManager.shared.showToast(from: self, type: .moreBenefit)
-        }
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -74,6 +71,11 @@ public final class DetailStoreInfoViewController: UIViewController, UIGestureRec
     
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        
+        if !toastHasBeenShown {
+            ToastManager.shared.showToast(from: self, type: .moreBenefit)
+            toastHasBeenShown = true
+        }
         
         detailStoreViewModel.onUseagesListModalChanged = { [weak self] isPresented in
             if isPresented {

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/SearchStoreViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/SearchStoreViewController.swift
@@ -84,6 +84,7 @@ final class SearchStoreViewController: UIViewController {
         super.viewWillAppear(animated)
         
         textField.becomeFirstResponder()
+        self.hideCustomTabBar()
     }
     
     @objc func backButtonTapped() {

--- a/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreMapViewController.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewController/StoreMapViewController.swift
@@ -96,10 +96,10 @@ final class StoreMapViewController: UIViewController {
         
         switch storeMapViewModel.storeMapTypeSubject.value {
         case .search:
-            tabBarController?.tabBar.isHidden = false
+            self.showCustomTabBar()
             searchBarView.configureSearchType(.search)
         case .searchResult:
-            tabBarController?.tabBar.isHidden = true
+            self.hideCustomTabBar()
         }
     }
     
@@ -173,8 +173,13 @@ private extension StoreMapViewController {
                 guard let self else { return }
                 
                 bottomSheetVC.view.isHidden = type == .search ? false : true
-                tabBarController?.tabBar.isHidden = type == .search ? false : true
                 storeInfoBottomView.isHidden = type == .searchResult ? false : true
+                
+                if type == .search {
+                    self.showCustomTabBar()
+                } else {
+                    self.hideCustomTabBar()
+                }
                 
                 if type == .search {
                     searchBarView.configureSearchType(.search)
@@ -468,7 +473,12 @@ private extension StoreMapViewController {
     
     func updateSearchLayout(_ store: StoreListModel, isHidden: Bool) {
         bottomSheetVC.view.isHidden = true
-        tabBarController?.tabBar.isHidden = isHidden
+        
+        if !isHidden {
+            self.showCustomTabBar()
+        } else {
+            self.hideCustomTabBar()
+        }
         
         storeInfoBottomView.snp.remakeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(15)
@@ -547,7 +557,7 @@ extension StoreMapViewController: NMFMapViewTouchDelegate {
             self.selectedMarker = nil
             self.bottomSheetVC.view.isHidden = false
             self.storeInfoBottomView.isHidden = true
-            self.tabBarController?.tabBar.isHidden = false
+            self.showCustomTabBar()
         }
     }
 }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/Coordinator/UniversityInfoCoordinator.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/Coordinator/UniversityInfoCoordinator.swift
@@ -52,8 +52,6 @@ final class UniversityInfoCoordinator: UniversityInfoCoordinating, PoppableCoord
             coordinator: self
         )
         self.rootViewController = universityInfoVC
-        
-        universityInfoVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(universityInfoVC, animated: true)
     }
     
@@ -64,7 +62,6 @@ final class UniversityInfoCoordinator: UniversityInfoCoordinating, PoppableCoord
             coordinator: self
         )
         
-        majorInfoVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(majorInfoVC, animated: true)
     }
     

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/CollegeInfoViewController.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/CollegeInfoViewController.swift
@@ -75,6 +75,12 @@ final class CollegeInfoViewController: UIViewController, UIGestureRecognizerDele
         
         viewLifeCycleSubject.send(.viewDidLoad)
     }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.hideCustomTabBar()
+    }
 }
 
 // MARK: - Private Bind Extensions

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/UniversityViewController.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/UniversityViewController.swift
@@ -75,6 +75,12 @@ public final class UniversityViewController: UIViewController, UIGestureRecogniz
         
         viewLifeCycleSubject.send(.viewDidLoad)
     }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.hideCustomTabBar()
+    }
 }
 
 // MARK: - Private Bind Extensions


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #78 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- iOS 26 이상에서 발생하는 TabBar 관련 리퀴드 글래스 UI 이슈 대응
- `UINavigationController` push 시 TabBar가 숨겨지지 않는 이슈 해결
- Custom TabBar 로직 안정화 및 코드 개선

<br>

## 📸 스크린샷
|기능|변경 전|변경 후|
|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/cc3718d3-ea6e-4e6d-adff-5dc569c7ff5a" width ="250">|<img src = "https://github.com/user-attachments/assets/3058b032-f2cc-4911-9a03-fbd58f146561" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. Custom TabBar Controller 구현 방식 변경

기존에는 `setValue(customTabBarView, forKey: "tabBar")`를 사용하여 시스템 TabBar를 Custom TabBar로 교체했으나, 이 방식은 iOS 26 이상에서 리퀴드 글래스로 변경된 UI 를 변경하고자 합니다.

새로운 방식에서는 기본 TabBar를 숨기고, Custom TabBar 를 `CustomTabBarController`의 최상위 View에 직접 추가합니다.

```swift
// CustomTabBarController.swift

public override func viewDidLoad() {
    super.viewDidLoad()
    
    // 1. 기본 TabBar 숨기기
    tabBar.isHidden = true

    // 2. Custom TabBar를 View에 추가
    view.addSubview(customTabBarView)
    view.clipsToBounds = true
    
    customTabBarView.snp.makeConstraints {
        $0.horizontalEdges.equalToSuperview()
        $0.bottom.equalToSuperview()
    }
}
```

<br>

### 2. TabBar 노출/숨김 처리

화면 이동 시 TabBar를 숨기기 위해 더 이상 `hidesBottomBarWhenPushed = true`를 사용하지 않습니다. 대신 `UIViewController` 확장을 통해 `showCustomTabBar()`와 `hideCustomTabBar()` 메서드를 제공합니다.

각 ViewController의 `viewWillAppear` 시점에서 이 메서드들을 호출하여 TabBar의 노출 여부를 명시적으로 제어합니다.

```swift
// UIViewController+Terbuck.swift

public extension UIViewController {
    /// CustomTabBarController의 탭바를 숨깁니다.
    func hideCustomTabBar() {
        guard let customTabBarController = self.tabBarController as? CustomTabBarController else { return }
        customTabBarController.hideTabBar()
    }
    
    /// CustomTabBarController의 탭바를 보여줍니다
    func showCustomTabBar() {
        guard let customTabBarController = self.tabBarController as? CustomTabBarController else { return }
        customTabBarController.showTabBar()
    }
}

// PartnershipViewController.swift (사용 예시)
public override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    
    self.hideCustomTabBar() // 화면이 나타날 때 TabBar를 숨김
}
```

<br>

### 3. TabBar SafeArea 동적 조절

TabBar의 노출 상태가 변경될 때, ViewController의 `additionalSafeAreaInsets.bottom` 값을 동적으로 조절하여 콘텐츠가 TabBar에 의해 가려지지 않도록 했습니다.

`CustomTabBarController`의 `updateSafeAreaInsetsForAllViewControllers()` 메서드가 이 역할을 수행하며, TabBar가 숨겨졌을 때는 `bottom` inset을 `0`으로, 노출되었을 때는 TabBar의 높이만큼 설정합니다.

```swift
// CustomTabBarController.swift

func updateSafeAreaInsetsForAllViewControllers() {
    let isTabBarHidden = customTabBarView.isHidden
    
    self.viewControllers?.forEach { viewController in
        if isTabBarHidden {
            viewController.additionalSafeAreaInsets.bottom = 0
        } else {
            if viewController == self.selectedViewController {
                let overlapHeight = customTabBarView.frame.height - view.safeAreaInsets.bottom
                viewController.additionalSafeAreaInsets.bottom = overlapHeight
            } else {
                viewController.additionalSafeAreaInsets.bottom = 0
            }
        }
    }
}
```

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
