### PR TITLE
[Fix] #82 - CustomTabBar 배경 설정

### DIFF
--- a/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
+++ b/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
@@ -85,7 +85,7 @@ private extension CustomTabBar {
     
     func setupHierarchy() {
         addSubviews(topSeparator, backgroundView)
-        backgroundView.addSubview(stackView)
+        backgroundView.addSubviews(stackView)
     }
     
     func setupLayout() {

--- a/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
+++ b/Terbuck/DesignSystem/Sources/Components/CustomTabBar.swift
@@ -24,6 +24,7 @@ public final class CustomTabBar: UITabBar {
     
     private var buttons: [UIButton] = []
     private let stackView = UIStackView()
+    private let backgroundView = UIView()
     private let topSeparator = UIView()
     
     // MARK: - Init
@@ -67,8 +68,6 @@ private extension CustomTabBar {
     }
     
     func setupStyle() {
-        self.backgroundColor = DesignSystem.Color.uiColor(.terbuckWhite)
-        
         stackView.do {
             $0.axis = .horizontal
             $0.distribution = .fillEqually
@@ -78,10 +77,15 @@ private extension CustomTabBar {
         topSeparator.do {
             $0.backgroundColor = DesignSystem.Color.uiColor(.terbuckWhite3)
         }
+        
+        backgroundView.do {
+            $0.backgroundColor = DesignSystem.Color.uiColor(.terbuckWhite)
+        }
     }
     
     func setupHierarchy() {
-        addSubviews(topSeparator, stackView)
+        addSubviews(topSeparator, backgroundView)
+        backgroundView.addSubview(stackView)
     }
     
     func setupLayout() {
@@ -91,9 +95,16 @@ private extension CustomTabBar {
             $0.height.equalTo(1)
         }
         
+        backgroundView.snp.makeConstraints {
+            $0.top.equalTo(topSeparator.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+        
         stackView.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(23)
+            $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(50)
+            $0.bottom.equalToSuperview().inset(23)
         }
     }
     


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #82 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- `CustomTabBar` 의 빈 공간 터치 시, 뒤에 있는 `CollectionView` 의 셀이 눌리는 이슈 해결
- 터치 이벤트를 정상적으로 처리하기 위한 backgroundView 추가 및 계층 구조 변경

<br>

## 📸 스크린샷
|기능|iPhone 17 Pro|iPhone 13 mini|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/75c67ade-4389-4554-9526-2d9e345cee97" width ="250">|<img src = "https://github.com/user-attachments/assets/ed299607-a0ae-44a1-ae4e-8758a8962000" width ="250">|

<br>

## 🚨 참고 사항
  
### ⚠️ 문제 원인
 
`CustomTabBar` 내부에 버튼을 담고 있는 `UIStackView` 는 좌우에 50pt의 여백(inset)을 가지고 있었습니다. 이로 인해 탭바의 가장 왼쪽과 오른쪽에 터치 이벤트가 발생할 경우, `UITabBar` 를 상속받은 `CustomTabBar` 가 해당 터치를 처리하지 않고 뒤에 있는 `CollectionView` 로 이벤트를 통과시키는 문제가 발생했습니다.

### 💡 해결 방법
터치 이벤트를 확실하게 받아줄 수 있는 `UIView` 를 배경으로 추가하여 문제를 해결했습니다.

1. `backgroundView` 라는 새로운 `UIView` 를 추가하여 `CustomTabBar` 의 전체 영역을 채우도록 했습니다.
2. 기존 `stackView` 를 이 `backgroundView` 의 자식 뷰(subview)로 배치했습니다.
3. `UIView` 는 기본적으로 배경색이 있을 경우 자신의 영역 내에서 발생하는 터치 이벤트를 소비하므로, 더 이상 터치가 뒤쪽 `CollectionView` 로 전달되지 않습니다.

### 🧩 변경된 뷰 계층 구조
   - 기존: CustomTabBar > UIStackView
   - 변경 후: CustomTabBar > backgroundView > UIStackView

이러한 구조 변경을 통해 탭바의 어느 곳을 터치하더라도 의도치 않은 동작이 발생하지 않도록 수정했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
