### PR TITLE
[Feat] #85 - 회원가입, 대학교 변경, 학생증 인증 관련 LottieActivityIndicatorView 구현

### DIFF
--- a/Terbuck/DesignSystem/Sources/Components/LottieActivityIndicatorView.swift
+++ b/Terbuck/DesignSystem/Sources/Components/LottieActivityIndicatorView.swift
@@ -53,16 +53,15 @@ public final class LottieActivityIndicatorView: UIView {
 // MARK: - Public func Extensions
 
 public extension LottieActivityIndicatorView {
-    func indicatorHidden(_ isHidden: Bool) {
-        self.activityIndicatorHidden = isHidden
-    }
-    
-    func playIndicator() {
-        activityIndicator.play()
-    }
-    
-    func stopIndicator() {
-        activityIndicator.stop()
+    func setAnimating(_ animating: Bool) {
+        isHidden = !animating
+        self.activityIndicatorHidden = !animating
+        
+        if animating {
+            activityIndicator.play()
+        } else {
+            activityIndicator.stop()
+        }
     }
 }
 
@@ -100,6 +99,20 @@ private extension LottieActivityIndicatorView {
     func setupHidden() {
         indicatorBackground.isHidden = activityIndicatorHidden
         activityIndicator.isHidden = activityIndicatorHidden
+    }
+}
+
+private extension LottieActivityIndicatorView {
+    func indicatorHidden(_ isHidden: Bool) {
+        self.activityIndicatorHidden = isHidden
+    }
+    
+    func playIndicator() {
+        activityIndicator.play()
+    }
+    
+    func stopIndicator() {
+        activityIndicator.stop()
     }
 }
 

--- a/Terbuck/DesignSystem/Sources/Components/LottieActivityIndicatorView.swift
+++ b/Terbuck/DesignSystem/Sources/Components/LottieActivityIndicatorView.swift
@@ -1,0 +1,115 @@
+//
+//  LottieActivityIndicatorView.swift
+//  DesignSystem
+//
+//  Created by ParkJunHyuk on 10/17/25.
+//
+
+import UIKit
+
+import Shared
+import Resource
+
+import SnapKit
+import Then
+import Lottie
+
+public final class LottieActivityIndicatorView: UIView {
+    
+    // MARK: - Properties
+    
+    private var activityIndicatorHidden = true {
+        didSet {
+            setupHidden()
+        }
+    }
+    
+    // MARK: - UI Properties
+    
+    private let indicatorBackground = UIView()
+    private let activityIndicator = LottieAnimationView(name: "LoadingIndicator", bundle: ResourceResources.bundle)
+    
+    // MARK: - Init
+
+    public init(isHidden: Bool = true) {
+        self.activityIndicatorHidden = isHidden
+        super.init(frame: .zero)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+        setupHidden()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        AppLogger.log("LottieActivityIndicatorView Deinit", .info, .ui)
+    }
+}
+
+// MARK: - Public func Extensions
+
+public extension LottieActivityIndicatorView {
+    func indicatorHidden(_ isHidden: Bool) {
+        self.activityIndicatorHidden = isHidden
+    }
+    
+    func playIndicator() {
+        activityIndicator.play()
+    }
+    
+    func stopIndicator() {
+        activityIndicator.stop()
+    }
+}
+
+// MARK: - Private Extensions
+
+private extension LottieActivityIndicatorView {
+    func setupStyle() {
+        indicatorBackground.do {
+            $0.backgroundColor = DesignSystem.Color.uiColor(.terbuckIndicatorBackground)
+        }
+        
+        activityIndicator.do {
+            $0.loopMode = .loop
+            $0.contentMode = .scaleAspectFit
+            $0.animationSpeed = 1.0
+        }
+    }
+    
+    func setupHierarchy() {
+        self.addSubviews(indicatorBackground)
+        indicatorBackground.addSubviews(activityIndicator)
+    }
+    
+    func setupLayout() {
+        indicatorBackground.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        activityIndicator.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.size.equalTo(self.convertByHeightRatio(200))
+        }
+    }
+    
+    func setupHidden() {
+        indicatorBackground.isHidden = activityIndicatorHidden
+        activityIndicator.isHidden = activityIndicatorHidden
+    }
+}
+
+// MARK: - Show Preview
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+#Preview("LottieActivityIndicatorView") {
+    LottieActivityIndicatorView()
+        .showPreview()
+}
+#endif

--- a/Terbuck/DesignSystem/Sources/Terbuck Design/TerbuckColor.swift
+++ b/Terbuck/DesignSystem/Sources/Terbuck Design/TerbuckColor.swift
@@ -30,6 +30,7 @@ public enum DesignSystem {
             case terbuckStudentBackground
             case terbuckPartnerBlack
             case terbuckBottomGradient
+            case terbuckIndicatorBackground
             
             var info: UIColor {
                 switch self {
@@ -68,6 +69,9 @@ public enum DesignSystem {
                     return UIColor(asset: ResourceAsset.Color.terbuckPartnerBlack)!
                 case .terbuckBottomGradient:
                     return UIColor(asset: ResourceAsset.Color.terbuckBottomGradient)!
+                case .terbuckIndicatorBackground:
+                    return UIColor(asset: ResourceAsset.Color.terbuckBlack50)!
+                        .withAlphaComponent(0.50)
                 }
             }
             

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewController/RegisterStudentCardViewController.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewController/RegisterStudentCardViewController.swift
@@ -140,14 +140,7 @@ private extension RegisterStudentCardViewController {
         registerStudentCardViewModel.isPlayIndicatorSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isPlay in
-                self?.activityIndicatorView.isHidden = !isPlay
-                self?.activityIndicatorView.indicatorHidden(!isPlay)
-                
-                if isPlay {
-                    self?.activityIndicatorView.playIndicator()
-                } else {
-                    self?.activityIndicatorView.stopIndicator()
-                }
+                self?.activityIndicatorView.setAnimating(isPlay)
             }
             .store(in: &cancellables)
     }

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewController/RegisterStudentCardViewController.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewController/RegisterStudentCardViewController.swift
@@ -27,7 +27,6 @@ public final class RegisterStudentCardViewController: UIViewController, UIGestur
     // MARK: - Combine Properties
     
     private var registerStudentIdImageSubject = PassthroughSubject<Data, Never>()
-    
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - UI Properties
@@ -43,6 +42,8 @@ public final class RegisterStudentCardViewController: UIViewController, UIGestur
     private let textFieldStackView = UIStackView()
     private let nameTextFieldView = TerbuckTextFieldView(type: .name)
     private let studentIdTextFieldView = TerbuckTextFieldView(type: .studentID)
+    
+    private let activityIndicatorView = LottieActivityIndicatorView(isHidden: true)
     
     // MARK: - Init
     
@@ -135,6 +136,20 @@ private extension RegisterStudentCardViewController {
                 NotificationCenter.default.post(name: .userAuthDidUpdate, object: nil)
             }
             .store(in: &cancellables)
+        
+        registerStudentCardViewModel.isPlayIndicatorSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlay in
+                self?.activityIndicatorView.isHidden = !isPlay
+                self?.activityIndicatorView.indicatorHidden(!isPlay)
+                
+                if isPlay {
+                    self?.activityIndicatorView.playIndicator()
+                } else {
+                    self?.activityIndicatorView.stopIndicator()
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -186,10 +201,12 @@ private extension RegisterStudentCardViewController {
             $0.clipsToBounds = true
             $0.isHidden = true
         }
+        
+        activityIndicatorView.isHidden = true
     }
     
     func setupHierarchy() {
-        self.view.addSubviews(customNavBar, titleLabel, subTitleLabel, containerView, textFieldStackView, bottomButton)
+        self.view.addSubviews(customNavBar, titleLabel, subTitleLabel, containerView, textFieldStackView, bottomButton, activityIndicatorView)
         containerView.addSubviews(registerStudentIDCardButton, studentIdImageView)
     }
     
@@ -230,6 +247,10 @@ private extension RegisterStudentCardViewController {
         bottomButton.snp.makeConstraints {
             $0.top.equalTo(textFieldStackView.snp.bottom).offset(view.convertByHeightRatio(120))
             $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        activityIndicatorView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
@@ -171,37 +171,3 @@ private extension RegisterStudentCardViewModel {
         .eraseToAnyPublisher()
     }
 }
-
-
-//let registerBottomButtonResult = input.bottomButtonTapped
-////            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: false)
-//    .handleEvents(receiveOutput:  { [weak self] _ in
-//        self?.isPlayIndicatorSubject.send(true)
-//        MixpanelManager.shared.track(eventType: TrackEventType.Home.registerButtonTappedInRegisterView)
-//    })
-//    .flatMap { [weak self] in
-//        guard let self else {
-//            return Just(false).eraseToAnyPublisher()
-//        }
-//
-////                return Just(true).eraseToAnyPublisher()
-//        return self.putStudentCardPublisher()
-//            .catch { _ in Just(false).eraseToAnyPublisher() }
-//            .eraseToAnyPublisher()
-//    }
-//    .map { isSuccess -> Bool in
-//        if isSuccess {
-////                    guard let imageData = self?.studentImageData else { return }
-////                    let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
-//            
-//            UserDefaultsManager.shared.set(false, for: .isStudentIDAuthenticated)
-//            FileStorageManager.shared.delete(type: .studentIdCard)
-//        }
-//        
-//        return isSuccess
-//    }
-//    .delay(for: .seconds(1), scheduler: RunLoop.main)
-//    .handleEvents(receiveOutput: { [weak self] _ in
-//        self?.isPlayIndicatorSubject.send(false)
-//    })
-//    .eraseToAnyPublisher()

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
@@ -33,6 +33,10 @@ public final class RegisterStudentCardViewModel {
     private var studentId: String?
     private var studentImageData: Data?
     
+    // MARK: - Public Combine Publishers Properties
+    
+    public let isPlayIndicatorSubject = PassthroughSubject<Bool, Never>()
+    
     // MARK: - Private Combine Publishers Properties
     
     private var cancellables = Set<AnyCancellable>()
@@ -95,32 +99,36 @@ public final class RegisterStudentCardViewModel {
         
         let registerBottomButtonResult = input.bottomButtonTapped
             .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: false)
-            .handleEvents(receiveOutput:  { _ in
-                MixpanelManager.shared.track(eventType: TrackEventType.Home.registerButtonTappedInRegisterView)
-            })
-            .flatMap { [weak self] in
+            .flatMap { [weak self] _ in
                 guard let self else {
                     return Just(false).eraseToAnyPublisher()
                 }
 
-                return self.putStudentCardPublisher()
-//                    .handleEvents(receiveOutput: { _ in
-//                        guard let imageData = self.studentImageData else { return }
-//                        
-//                        let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
-//                    })
+                self.isPlayIndicatorSubject.send(true)
+                MixpanelManager.shared.track(eventType: TrackEventType.Home.registerButtonTappedInRegisterView)
+
+                let apiResultPublisher = self.putStudentCardPublisher()
                     .catch { _ in Just(false).eraseToAnyPublisher() }
+                    .map { isSuccess -> Bool in
+                        if isSuccess {
+                            UserDefaultsManager.shared.set(false, for: .isStudentIDAuthenticated)
+                            FileStorageManager.shared.delete(type: .studentIdCard)
+                        }
+                        return isSuccess
+                    }
+
+                let minDurationPublisher = Just(())
+                    .delay(for: .seconds(1), scheduler: RunLoop.main)
+
+                return Publishers.Zip(apiResultPublisher, minDurationPublisher)
+                    .map { (apiResult, _) -> Bool in
+                        return apiResult
+                    }
+                    .handleEvents(receiveOutput: { [weak self] _ in
+                        self?.isPlayIndicatorSubject.send(false)
+                    })
                     .eraseToAnyPublisher()
             }
-            .handleEvents(receiveOutput: { [weak self] isSuccess in
-                if isSuccess {
-//                    guard let imageData = self?.studentImageData else { return }
-//                    let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
-                    
-                    UserDefaultsManager.shared.set(false, for: .isStudentIDAuthenticated)
-                    FileStorageManager.shared.delete(type: .studentIdCard)
-                }
-            })
             .eraseToAnyPublisher()
         
         return Output(
@@ -163,3 +171,37 @@ private extension RegisterStudentCardViewModel {
         .eraseToAnyPublisher()
     }
 }
+
+
+//let registerBottomButtonResult = input.bottomButtonTapped
+////            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: false)
+//    .handleEvents(receiveOutput:  { [weak self] _ in
+//        self?.isPlayIndicatorSubject.send(true)
+//        MixpanelManager.shared.track(eventType: TrackEventType.Home.registerButtonTappedInRegisterView)
+//    })
+//    .flatMap { [weak self] in
+//        guard let self else {
+//            return Just(false).eraseToAnyPublisher()
+//        }
+//
+////                return Just(true).eraseToAnyPublisher()
+//        return self.putStudentCardPublisher()
+//            .catch { _ in Just(false).eraseToAnyPublisher() }
+//            .eraseToAnyPublisher()
+//    }
+//    .map { isSuccess -> Bool in
+//        if isSuccess {
+////                    guard let imageData = self?.studentImageData else { return }
+////                    let _ = FileStorageManager.shared.saveData(data: imageData, type: .studentIdCard)
+//            
+//            UserDefaultsManager.shared.set(false, for: .isStudentIDAuthenticated)
+//            FileStorageManager.shared.delete(type: .studentIdCard)
+//        }
+//        
+//        return isSuccess
+//    }
+//    .delay(for: .seconds(1), scheduler: RunLoop.main)
+//    .handleEvents(receiveOutput: { [weak self] _ in
+//        self?.isPlayIndicatorSubject.send(false)
+//    })
+//    .eraseToAnyPublisher()

--- a/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
+++ b/Terbuck/Feature/RegisterStudentCardFeature/Sources/ViewModel/RegisterStudentCardViewModel.swift
@@ -35,7 +35,7 @@ public final class RegisterStudentCardViewModel {
     
     // MARK: - Public Combine Publishers Properties
     
-    public let isPlayIndicatorSubject = PassthroughSubject<Bool, Never>()
+    public let isPlayIndicatorSubject = CurrentValueSubject<Bool, Never>(false)
     
     // MARK: - Private Combine Publishers Properties
     

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/CollegeInfoViewController.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/CollegeInfoViewController.swift
@@ -134,15 +134,7 @@ private extension CollegeInfoViewController {
         viewModel.isPlayIndicatorSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isPlay in
-                
-                self?.activityIndicatorView.isHidden = !isPlay
-                self?.activityIndicatorView.indicatorHidden(!isPlay)
-                
-                if isPlay {
-                    self?.activityIndicatorView.playIndicator()
-                } else {
-                    self?.activityIndicatorView.stopIndicator()
-                }
+                self?.activityIndicatorView.setAnimating(isPlay)
             }
             .store(in: &cancellables)
     }

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/CollegeInfoViewController.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewController/CollegeInfoViewController.swift
@@ -35,6 +35,7 @@ final class CollegeInfoViewController: UIViewController, UIGestureRecognizerDele
     private let titleView: InformationTitleView
     private let terbuckBottomButton: TerbuckBottomButton
     private let hostingController: UIHostingController<CollegeSectionView>
+    private let activityIndicatorView = LottieActivityIndicatorView(isHidden: true)
     
     // MARK: - Init
     
@@ -59,7 +60,7 @@ final class CollegeInfoViewController: UIViewController, UIGestureRecognizerDele
     }
     
     deinit {
-        AppLogger.log("MajorInfoViewController Deinit", .info, .ui)
+        AppLogger.log("CollegeInfoViewController Deinit", .info, .ui)
     }
     
     // MARK: - Life Cycle
@@ -124,9 +125,24 @@ private extension CollegeInfoViewController {
             .sink { [weak self] errorcase in
                 self?.showConfirmAlert(
                     mainTitle: errorcase.errorDescription,
-                    subTitle: "잠시 후 다시 시도해주세요\n",
+                    subTitle: errorcase.errorSubTitle,
                     centerButton: TerbuckBottomButton(type: .confirm)
                 )
+            }
+            .store(in: &cancellables)
+        
+        viewModel.isPlayIndicatorSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlay in
+                
+                self?.activityIndicatorView.isHidden = !isPlay
+                self?.activityIndicatorView.indicatorHidden(!isPlay)
+                
+                if isPlay {
+                    self?.activityIndicatorView.playIndicator()
+                } else {
+                    self?.activityIndicatorView.stopIndicator()
+                }
             }
             .store(in: &cancellables)
     }
@@ -143,11 +159,13 @@ private extension CollegeInfoViewController {
         customNavBar.setupBackButtonAction { [weak self] in
             self?.coordinator?.backNavigation()
         }
+        
+        activityIndicatorView.isHidden = true
     }
     
     func setupHierarchy() {
         addChild(hostingController)
-        view.addSubviews(customNavBar, titleView, hostingController.view, terbuckBottomButton)
+        view.addSubviews(customNavBar, titleView, hostingController.view, terbuckBottomButton, activityIndicatorView)
     }
     
     func setupLayout() {
@@ -171,6 +189,10 @@ private extension CollegeInfoViewController {
             $0.top.equalTo(titleView.snp.bottom).offset(view.convertByHeightRatio(120))
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(view.convertByHeightRatio(360))
+        }
+        
+        activityIndicatorView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
     

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/CollegeInfoViewModel.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/ViewModel/CollegeInfoViewModel.swift
@@ -13,7 +13,7 @@ import Shared
 public enum CollegesError: LocalizedError, Equatable {
     case fetchFailed
     case signupFailed
-    case notEditUniversity
+    case equalEditUniversity
     case editUniversityFailed
     case unknown
     
@@ -23,12 +23,21 @@ public enum CollegesError: LocalizedError, Equatable {
             return "대학교 단과대 정보를 불러올 수 없습니다"
         case .signupFailed:
             return "가입 관련해서 문제가 발생했어요"
-        case .notEditUniversity:
-            return "대학교 인증 문제가 발생했어요"
+        case .equalEditUniversity:
+            return "대학교 변경 문제가 발생했어요"
         case .editUniversityFailed:
             return "대학교 변경에 문제가 발생했어요"
         case .unknown:
             return "알 수 없는 오류가 발생했어요"
+        }
+    }
+    
+    var errorSubTitle: String{
+        switch self {
+        case .equalEditUniversity:
+            return "다른 대학교를 선택해주세요"
+        default:
+            return "잠시 후 다시 시도해주세요\n"
         }
     }
 }
@@ -44,6 +53,7 @@ public class CollegeInfoViewModel {
     
     // MARK: - Public Combine Publishers Properties
     
+    public var isPlayIndicatorSubject = CurrentValueSubject<Bool, Never>(false)
     public var errorSubject = PassthroughSubject<CollegesError, Never>()
     
     // MARK: - Private Combine Publishers Properties
@@ -128,10 +138,14 @@ public class CollegeInfoViewModel {
                     return Just(false).eraseToAnyPublisher()
                 }
                 
+                self.isPlayIndicatorSubject.send(true)
+                
                 let universityName = self.selectedUniversityNameSubject.value
                 
+                let apiResultPublisher: AnyPublisher<Bool, Never>
+                
                 if let _ = self.signupUseCase {
-                    return self.signupPublisher(universityName, selectCollege.id)
+                    apiResultPublisher = self.signupPublisher(universityName, selectCollege.id)
                         .handleEvents(receiveOutput:  { _ in
                             MixpanelManager.shared.track(eventType: TrackEventType.Signup.secondSignupButtonTapped)
                             MixpanelManager.shared.setupUniversity(universityName: universityName)
@@ -146,10 +160,8 @@ public class CollegeInfoViewModel {
                             return Just(false)
                         }
                         .eraseToAnyPublisher()
-                }
-                
-                if let _ = self.editUniversityUseCase {
-                    return self.editUniversityPublisher(universityName, selectCollege.id)
+                } else if let _ = self.editUniversityUseCase {
+                    apiResultPublisher = self.editUniversityPublisher(universityName, selectCollege.id)
                         .map { _ in
                             UserDefaultsManager.shared.set(false, for: .isStudentIDAuthenticated)
                             UserDefaultsManager.shared.set(universityName, for: .university)
@@ -162,9 +174,21 @@ public class CollegeInfoViewModel {
                             return Just(false)
                         }
                         .eraseToAnyPublisher()
+                } else {
+                    apiResultPublisher = Just(false).eraseToAnyPublisher()
                 }
 
-                return Just(false).eraseToAnyPublisher()
+                let minDurationPublisher = Just(())
+                    .delay(for: .seconds(1), scheduler: RunLoop.main)
+
+                return Publishers.Zip(apiResultPublisher, minDurationPublisher)
+                    .map { (apiResult, _) -> Bool in
+                        return apiResult
+                    }
+                    .handleEvents(receiveOutput: { [weak self] _ in
+                        self?.isPlayIndicatorSubject.send(false)
+                    })
+                    .eraseToAnyPublisher()
             }
             .eraseToAnyPublisher()
         
@@ -238,7 +262,7 @@ private extension CollegeInfoViewModel {
             }
             
             if university == UserDefaultsManager.shared.string(for: .university) {
-                promise(.failure(.notEditUniversity))
+                promise(.failure(.equalEditUniversity))
                 return
             }
             


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #85 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- API 통신 시 로딩 상태를 표시하는 `LottieActivityIndicatorView` 컴포넌트 구현
- 학생증 인증, 회원가입, 대학교 변경 기능에 로딩 인디케이터 UI 및 로직 적용
- `Publishers.Zip`을 활용하여 최소 1초의 로딩 시간을 보장하는 로직 구현

<br>

## 📸 스크린샷
|기능|학생증 인증|회원가입, 대학교 변경|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/e5ceb61c-d800-4b15-828a-c09dba6eb6a3" width ="250">|<img src = "https://github.com/user-attachments/assets/6bfb6a18-b379-4ee1-9dae-1bf0f8da1170" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. LottieActivityIndicatorView 구현

Lottie 애니메이션을 사용하여 로딩 중임을 나타내는 재사용 가능한 `LottieActivityIndicatorView`를 `DesignSystem` 모듈에 추가했습니다. 이 뷰는 반투명 배경을 포함하여 로딩 중에 다른 UI 상호작용을 막는 역할을 합니다. `indicatorHidden(_:)`, `playIndicator()`, `stopIndicator()` 메서드를 통해 간단하게 제어할 수 있습니다.

<br>

### 2. 최소 로딩 시간 보장 로직 (with `Publishers.Zip`)

API 통신이 너무 빨리 완료될 경우, 인디케이터가 '깜빡'하고 사라져 사용자 경험을 해치는 것을 방지하기 위해 **최소 1초의 로딩 시간을 보장**하는 로직을 구현했습니다. 

`Publishers.Zip`을 사용하여 실제 API 호출을 처리하는 `apiResultPublisher`와, 최소 시간을 보장하는 `minDurationPublisher` (1초 딜레이)를 함께 실행합니다. `Zip`은 두 퍼블리셔가 모두 완료될 때까지 기다리므로 API 호출이 1초 안에 끝나더라도 최소 1초가 지난 시점에 인디케이터가 사라지게 됩니다.

```swift
// ViewModel의 API 호출 스트림 예시

// 1. 인디케이터 보이기
self.isPlayIndicatorSubject.send(true)

// 2. 실제 API 호출 퍼블리셔
let apiResultPublisher = self.someApiCallPublisher()
    .catch { _ in Just(false).eraseToAnyPublisher() }
    .map { ... }

// 3. 최소 1초 시간 보장용 타이머 퍼블리셔
let minDurationPublisher = Just(())
    .delay(for: .seconds(1), scheduler: RunLoop.main)

// 4. Zip으로 두 작업이 모두 끝나길 기다림
return Publishers.Zip(apiResultPublisher, minDurationPublisher)
    .map { (apiResult, _) -> Bool in
        return apiResult // API 결과만 사용
    }
    .handleEvents(receiveOutput: { [weak self] _ in
        // 5. 모든 작업이 끝나면 인디케이터 숨기기
        self?.isPlayIndicatorSubject.send(false)
    })
    .eraseToAnyPublisher()
```

이 로직을 **학생증 인증**(`RegisterStudentCardViewModel`)과 **단과대 정보 선택**(`CollegeInfoViewModel`) 두 곳에 모두 적용하여 일관된 사용자 경험을 제공하도록 했습니다.

<br>




## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
