### PR TITLE
[Fix] #88 - 대학교 변경 시 홈 화면 데이터 재로드 로직 구현

### DIFF
--- a/Terbuck/DesignSystem/Sources/Components/CustomTabBarController.swift
+++ b/Terbuck/DesignSystem/Sources/Components/CustomTabBarController.swift
@@ -88,12 +88,8 @@ private extension CustomTabBarController {
                 viewController.additionalSafeAreaInsets.bottom = 0
             } else {
                 // 탭바가 보일 때만 기존 로직을 실행
-                if viewController == self.selectedViewController {
-                    let overlapHeight = customTabBarView.frame.height - view.safeAreaInsets.bottom
-                    viewController.additionalSafeAreaInsets.bottom = overlapHeight
-                } else {
-                    viewController.additionalSafeAreaInsets.bottom = 0
-                }
+                let overlapHeight = customTabBarView.frame.height - view.safeAreaInsets.bottom
+                viewController.additionalSafeAreaInsets.bottom = overlapHeight
             }
         }
     }

--- a/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
@@ -173,9 +173,11 @@ private extension HomeViewController {
             .store(in: &cancellables)
         
         homeViewModel.currentMyUniversitySubject
+            .filter { !$0.isEmpty }
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
-                self?.viewLifeCycleSubject.send(.viewDidLoad)
+                self?.viewLifeCycleSubject.send(.reloadData)
             }
             .store(in: &cancellables)
         

--- a/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewController/HomeViewController.swift
@@ -171,6 +171,14 @@ private extension HomeViewController {
                 self?.homeViewModel.selectedFilterSubject.send(filterType)
             }
             .store(in: &cancellables)
+        
+        homeViewModel.currentMyUniversitySubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.viewLifeCycleSubject.send(.viewDidLoad)
+            }
+            .store(in: &cancellables)
+        
     }
 }
 

--- a/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
@@ -27,15 +27,18 @@ enum HomeError: LocalizedError, Equatable {
 
 public final class HomeViewModel {
     
-    // MARK: - Properties
+    // MARK: - UseCase Properties
     
-    private let locationManager = CLLocationManager()
     private let searchStoreUseCase: SearchStoreUseCase
     private let searchPartnershipUseCase: SearchPartnershipUseCase
     private let fetchPartnershipDisclosureStatusUseCase: FetchPartnershipDisclosureStatusUseCase
     private let requestPartnershipDisclosureUseCase: RequestPartnershipDisclosureUseCase
     private let fetchDisclosureRequestStatusUseCase: FetchDisclosureRequestStatusUseCase
     private let fetchApprovedStudentIdStatusUseCase: FetchApprovedStudentIdStatusUseCase
+    
+    // MARK: - Properties
+    
+    private let locationManager = CLLocationManager()
     
     // MARK: - Private Combine Publishers Properties
     
@@ -51,6 +54,7 @@ public final class HomeViewModel {
     public var sectionDataSubject = CurrentValueSubject<[HomeSection: [HomeItem]], Never>([:])
     public let myLocationSubject = CurrentValueSubject<(latitude: Double?, longitude: Double?), Never>((nil, nil))
     public let emptyStateButtonTapSubject = PassthroughSubject<Void, Never>()
+    public let currentMyUniversitySubject = CurrentValueSubject<String, Never>("")
     
     // MARK: - Input
     
@@ -119,6 +123,14 @@ public final class HomeViewModel {
             .filter { $0 == .viewWillAppear }
             .sink { [weak self] _ in
                 self?.isAuthStudentSubject.send(UserDefaultsManager.shared.bool(for: .isStudentIDAuthenticated))
+                
+                guard let storedUniversityName = UserDefaultsManager.shared.string(for: .university) else { return }
+                
+                let currentUniversityName = self?.currentMyUniversitySubject.value
+                
+                if currentUniversityName != storedUniversityName {
+                    self?.currentMyUniversitySubject.send(storedUniversityName)
+                }
             }
             .store(in: &cancellables)
         

--- a/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
+++ b/Terbuck/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
@@ -95,7 +95,7 @@ public final class HomeViewModel {
         
         // viewDidLoad 이벤트 처리
         input.viewLifeCycleEventAction
-            .filter { $0 == .viewDidLoad }
+            .filter { $0 == .viewDidLoad || $0 == .reloadData }
             .handleEvents(receiveOutput: { [weak self] _ in
                 self?.homeDataStateSubject.send(.loading)
             })

--- a/Terbuck/Feature/StoreFeature/Sources/ViewModel/StoreMapViewModel.swift
+++ b/Terbuck/Feature/StoreFeature/Sources/ViewModel/StoreMapViewModel.swift
@@ -98,6 +98,8 @@ public final class StoreMapViewModel {
                     if let name = self?.currentUniversityName, savedUniversityName != name {
                         self?.fetchStoreCategory()
                     }
+                case .reloadData:
+                    break
                 }
             }
             .store(in: &cancellables)

--- a/Terbuck/Shared/Sources/Enum/ViewLifeCycleEvent.swift
+++ b/Terbuck/Shared/Sources/Enum/ViewLifeCycleEvent.swift
@@ -10,4 +10,5 @@ import Foundation
 public enum ViewLifeCycleEvent {
     case viewDidLoad
     case viewWillAppear
+    case reloadData
 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #88 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 대학교 정보 변경 시 홈 화면이 자동으로 새로고침되도록 로직 구현
- 탭 전환 시 홈 화면의 버튼 레이아웃이 깨지는 버그 수정

<br>

## 📸 스크린샷
|기능|대학교 변경|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/7c8808e3-af1e-47e5-a20f-16cee435e3dc" width ="250">|

<br>

## 🚨 참고 사항
### 1. 홈 화면 자동 새로고침

다른 탭(예: 마이페이지)에서 대학교 정보를 변경한 후 홈 탭으로 돌아왔을 때, 변경된 대학교의 제휴 정보가 표시되도록 자동 새로고침 기능을 추가했습니다.

- `HomeViewModel`은 `viewWillAppear` 시점에 `UserDefaults`에 저장된 대학교 이름과 현재 `ViewModel`이 가지고 있는 대학교 이름을 비교합니다.
- 만약 두 이름이 다를 경우, `currentMyUniversitySubject`라는 `Subject`를 통해 변경된 이름을 방출합니다.
- `HomeViewController`는 이 `Subject`를 구독하고 있다가 새로운 값이 들어오면 `viewDidLoad` 이벤트를 다시 발생시켜 `ViewModel`이 모든 데이터를 새로 불러오도록 합니다.

<br>

### 2. 탭 전환 시 레이아웃 버그 수정

**문제 원인**
`CustomTabBarController`에서 **선택된 탭의 ViewController**에만 `additionalSafeAreaInsets.bottom`을 적용하고, 나머지 ViewController는 0으로 리셋하고 있었습니다. 이 때문에 홈 화면이 보이지 않는 상태가 되면 `safeAreaLayoutGuide`가 화면 최하단까지 확장되어, 여기에 제약조건이 잡혀있던 버튼의 레이아웃이 깨지는 문제가 있었습니다.

**해결 방법**
`updateSafeAreaInsetsForAllViewControllers()` 메서드의 로직을 수정하여, 탭이 선택되었는지 여부와 관계없이 **모든 자식 ViewController**에 대해 `additionalSafeAreaInsets.bottom`을 동일하게 적용하도록 변경했습니다. 이를 통해 탭 전환 시에도 모든 ViewController의 `safeAreaLayoutGuide`가 일관된 값을 유지하도록 하여 레이아웃이 깨지는 문제를 해결했습니다.

```swift
// CustomTabBarController.swift

func updateSafeAreaInsetsForAllViewControllers() {
    let isTabBarHidden = customTabBarView.isHidden
    
    self.viewControllers?.forEach { viewController in
        if isTabBarHidden {
            viewController.additionalSafeAreaInsets.bottom = 0
        } else {
            // 👇 선택 여부와 관계없이 모든 VC에 동일하게 Inset 적용
            let overlapHeight = customTabBarView.frame.height - view.safeAreaInsets.bottom
            viewController.additionalSafeAreaInsets.bottom = overlapHeight
        }
    }
}
```

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
