### PR TITLE
[Refactor] #90 - 회원가입, 대학교 변경 시 지역 선택으로 시작하도록 로직 변경

### DIFF
--- a/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
@@ -19,7 +19,7 @@ struct InfomationSectionView: View {
     
     @State var viewModel: UniversityViewModel
     @State private var isExpanded: Bool = true
-    @State private var sectionType: SectionType = .university
+    @State private var sectionType: SectionType = .location
     @State private var selectedSectionIndex: Int = 0
     
     // MARK: - Properties
@@ -74,7 +74,7 @@ struct InfomationSectionView: View {
                 }
                 .padding(.horizontal, 20)
                 .onAppear {
-                    sectionType = .university
+                    sectionType = .location
                     isExpanded = true
                 }
                 .transition(.opacity)

--- a/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
+++ b/Terbuck/Feature/UniversityInfoFeature/Sources/View/InfomationSectionView.swift
@@ -73,10 +73,6 @@ struct InfomationSectionView: View {
                     accordionSectionView(universityInfo: universityInfo, currentSection: currentSection)
                 }
                 .padding(.horizontal, 20)
-                .onAppear {
-                    sectionType = .location
-                    isExpanded = true
-                }
                 .transition(.opacity)
             } else {
                 VStack(spacing: 0) {

--- a/Terbuck/Project.swift
+++ b/Terbuck/Project.swift
@@ -5,7 +5,7 @@ import ProjectDescription
 let projectSettings: Settings = .settings(
     base: [
         "MARKETING_VERSION": "1.0.3",
-        "CURRENT_PROJECT_VERSION": "1",
+        "CURRENT_PROJECT_VERSION": "3",
         "DEVELOPMENT_TEAM": "N3H27N59VG",
         "CODE_SIGN_STYLE": "Automatic",
         "OTHER_LDFLAGS": ["-all_load"],


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #90 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 대학교 선택 화면의 초기 진입점을 '지역 선택'으로 변경
- 프로젝트 빌드 버전 업데이트

<br>

## 📸 스크린샷
|기능|대학교 변경|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/1d66844d-036c-4f49-a7ea-dc23ac87c1d8" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1.   대학교 선택 플로우 변경

기존에는 회원가입 또는 대학교 변경 시, 대학교 선택 화면에 진입하면 바로 전체 대학교 목록이 표시되었습니다.
사용자가 자신의 대학교를 더 쉽게 찾을 수 있도록, '지역'을 먼저 선택하고 해당 지역에 속한 대학교 목록을 보도록 초기 진입 플로우를 변경했습니다.

`InfomationSectionView` 의 `sectionType` 상태 변수 초기값을 `.university` 에서 `.location` 으로 수정하여, 뷰가 나타날 때 지역 선택 섹션이 먼저 보이도록 수정했습니다.

``` Swift
// InfomationSectionView.swift

// 변경 전
@State private var sectionType: SectionType = .university

// 변경 후
@State private var sectionType: SectionType = .location
```

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
